### PR TITLE
fix: Default value in lookup field.

### DIFF
--- a/src/lang/ADempiere/en/fieldOptions.js
+++ b/src/lang/ADempiere/en/fieldOptions.js
@@ -37,6 +37,10 @@ const fieldOptions = {
     thisWindow: ' and this Window',
     allWindows: ' and all Windows'
   },
+  // field info
+  info: {
+    defaultValue: 'Default Value'
+  },
   hideThisField: 'Hide This Field'
 }
 

--- a/src/lang/ADempiere/es/fieldOptions.js
+++ b/src/lang/ADempiere/es/fieldOptions.js
@@ -37,6 +37,10 @@ const fieldOptions = {
     thisWindow: ' y esta Ventana',
     allWindows: ' y todas las Ventanas'
   },
+  // field info
+  info: {
+    defaultValue: 'Valor Predeterminado'
+  },
   hideThisField: 'Ocultar Este Campo'
 }
 

--- a/src/store/modules/ADempiere/lookupManager.js
+++ b/src/store/modules/ADempiere/lookupManager.js
@@ -294,6 +294,7 @@ const lookupManager = {
       parentUuid,
       containerUuid,
       contextColumnNames,
+      contextColumnNamesByDefaultValue = [],
       uuid
     }) => {
       const contextAttributesList = getContextAttributes({
@@ -311,13 +312,19 @@ const lookupManager = {
         contextAttributesList
       })
 
-      // set item values getter from server into list
+      // get of stored default value
       if (isEmptyValue(optionsList)) {
+        const contextAttributesListByDefaultValue = getContextAttributes({
+          parentUuid,
+          containerUuid,
+          contextColumnNames: contextColumnNamesByDefaultValue,
+          isBooleanToString: true
+        })
         const option = rootGetters.getStoredDefaultValue({
           parentUuid,
           containerUuid,
           contextColumnNames,
-          contextAttributesList,
+          contextAttributesList: contextAttributesListByDefaultValue,
           uuid
         })
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window.
2. Select `New Record` action

See Client and Organization fields.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/162358194-6dcd18fa-42bc-4885-ad90-d944e9dc0f6c.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/162358214-bca70c10-4aa2-4478-bbb8-94fe02c19b0e.mp4

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes https://github.com/adempiere/adempiere-vue/issues/1718, fixes https://github.com/adempiere/adempiere-vue/issues/1490
