### PR TITLE
keep the type of report when changing the print format

### DIFF
--- a/src/store/modules/ADempiere/dictionary/report/actions.js
+++ b/src/store/modules/ADempiere/dictionary/report/actions.js
@@ -154,12 +154,13 @@ export default {
           icon: 'el-icon-document',
           enabled: true,
           svg: false,
-          actionName: 'runReportAs',
+          actionName: 'runReportAsPrintFormat',
           uuid: null,
-          runReportAs: ({ root, containerUuid }) => {
+          runReportAsPrintFormat: ({ root, containerUuid, reportFormat }) => {
             root.$store.dispatch('startReport', {
               containerUuid,
-              printFormatUuid: printFormat.printFormatUuid
+              printFormatUuid: printFormat.printFormatUuid,
+              reportFormat
             })
           }
         })
@@ -180,12 +181,13 @@ export default {
           icon: 'el-icon-document',
           enabled: true,
           svg: false,
-          actionName: 'runReportAs',
+          actionName: 'runReportAsView',
           uuid: null,
-          runReportAs: ({ root, containerUuid }) => {
+          runReportAsView: ({ root, containerUuid, reportFormat }) => {
             root.$store.dispatch('startReport', {
               containerUuid,
-              reportViewUuid: reportView.reportViewUuid
+              reportViewUuid: reportView.reportViewUuid,
+              reportFormat
             })
           }
         })

--- a/src/views/ADempiere/ReportViewer/index.vue
+++ b/src/views/ADempiere/ReportViewer/index.vue
@@ -27,6 +27,7 @@
           :container-uuid="reportUuid"
           :actions-manager="actionsManager"
           :relations-manager="relationsManager"
+          :report-format="reportFormat"
         />
         <br>
         <div class="content">


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
keep the type of report when changing the print format
#### Steps to reproduce

1. Open a generated PDF report
2. After it is generated, change the print format or the view of the report
3. Observe the error (the print format or the view of the report is not generated in PDF, it is always generated in HTML)

### Screenshot or Gif
#### GIF Error
![error-vue](https://user-images.githubusercontent.com/45974454/167941692-7b03c625-821b-4b29-a266-3b408855d4f1.gif)

#### GIF  Expected behavior (Interface ZK)
![zk](https://user-images.githubusercontent.com/45974454/167941756-59fe8e50-dc72-424a-9ded-f9b5f8193543.gif)

#### GIF Success
![success](https://user-images.githubusercontent.com/45974454/167941913-a1733adb-c8e9-4bca-8589-75d68c61be15.gif)


#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome
- Node.js version: v 14.0.0
- Yarn version: v 1.22.0
- adempiere-vue version: v 4.4.0.

#### Additional context
Note: This PR is linked with the following PR of the [Frontend Default Theme](https://github.com/solop-develop/frontend-default-theme) [#15](https://github.com/solop-develop/frontend-default-theme/pull/15)

