### PR TITLE
fix: Docs video width in mobile.

### DIFF
--- a/docs/es/guide/use-cases/process.md
+++ b/docs/es/guide/use-cases/process.md
@@ -8,10 +8,10 @@ Aperturar un proceso dede el arbol de menú:
 2. Seleccionar el proceso **Envío Texto Correo Electrónico**.
 
 ##### Versión ZK:
-<img :src="$withBase('/images/use-cases/process-opened-menu-zk.gif')" alt="ZK Desktop" width="800px">
+<img :src="$withBase('/images/use-cases/process-opened-menu-zk.gif')" alt="ZK Desktop" width="100%">
 
 ##### Versión Vue:
-<img :src="$withBase('/images/use-cases/process-opened-menu-vue.gif')" alt="ZK Desktop" width="800px">
+<img :src="$withBase('/images/use-cases/process-opened-menu-vue.gif')" alt="ZK Desktop" width="100%">
 
 
 
@@ -23,7 +23,7 @@ Aperturar un proceso desde el buscador del menú:
 3. Seleccionar el proceso coincidente con el resultado.
 
 ##### Versión ZK:
-<video width="800px" controls>
+<video width="100%" controls>
   <source type="video/mp4" :src="$withBase('/images/use-cases/process-menu-lookup-zk.mp4')">
   Your browser does not support the mp4 video tag.
 </video>
@@ -33,7 +33,7 @@ Aperturar un proceso desde el buscador del menú:
 2. En el buscador que se despliega escribir **Envío Texto Correo Electrónico**.
 3. Seleccionar el proceso coincidente con el resultado.
 
-<video width="800px" controls>
+<video width="100%" controls>
   <source type="video/mp4" :src="$withBase('/images/use-cases/process-menu-lookup-vue.mp4')">
   Your browser does not support the mp4 video tag.
 </video>
@@ -47,7 +47,7 @@ Aperturar un proceso de ítems recientes:
 2. Seleccionar caulquier proceso.
 
 ##### Versión Vue:
-<video width="800px" controls>
+<video width="100%" controls>
   <source type="video/mp4" :src="$withBase('/images/use-cases/process-recent-items-vue.mp4')">
   Your browser does not support the mp4 video tag.
 </video>
@@ -64,7 +64,7 @@ Aperturar un proceso desde las relaciones del mismo nivel del menú:
 El cliente ZK de ADempiere no cuenta con una caracteristica equivalente.
 
 ##### Versión Vue:
-<video width="800px" controls>
+<video width="100%" controls>
   <source type="video/mp4" :src="$withBase('/images/use-cases/process-relations-vue.mp4')">
   Your browser does not support the mp4 video tag.
 </video>
@@ -80,7 +80,7 @@ Abrir los procesos asociados en la ventana:
 3. Dar clic en el icono del engranaje, en la barra superior, para listar los procesos.
 4. Seleccionar el proceso **Generar Token para Acceso de Terceros**
 
-<video width="800px" controls>
+<video width="100%" controls>
   <source type="video/mp4" :src="$withBase('/images/use-cases/process-window-zk.mp4')">
   Your browser does not support the mp4 video tag.
 </video>
@@ -91,7 +91,7 @@ Abrir los procesos asociados en la ventana:
 3. En la parte superior a la derecha listar, listar el menú de acciones.
 4. Seleccionar el proceso **Generar Token para Acceso de Terceros**
 
-<video width="800px" controls>
+<video width="100%" controls>
   <source type="video/mp4" :src="$withBase('/images/use-cases/process-window-vue.mp4')">
   Your browser does not support the mp4 video tag.
 </video>
@@ -108,7 +108,7 @@ El cliente ZK de ADempiere no cuenta con una caracteristica equivalente.
 ##### Versión Vue:
 1. Ubicar en el árbol de menú en **Histórico Procesos** y abrirlo.
 2. Seleccionar cualquier proceso con parametros **Envío Texto Correo Electrónico**.
-<video width="800px" controls>
+<video width="100%" controls>
   <source type="video/mp4" :src="$withBase('/images/use-cases/process-relations-vue.mp4')">
   Your browser does not support the mp4 video tag.
 </video>
@@ -122,10 +122,10 @@ Los parámetros (campos) de los procesos deben cargar al abrirse en el caso de q
 2. Notese los diferentes tipos de parámetros: Cadena, Si y No, Fecha, Monto, Lista, Tabla.
 
 ##### Versión ZK:
-<img :src="$withBase('/images/use-cases/process-parameters-zk.png')" alt="ZK Desktop" width="800px">
+<img :src="$withBase('/images/use-cases/process-parameters-zk.png')" alt="ZK Desktop" width="100%">
 
 ##### Versión Vue:
-<img :src="$withBase('/images/use-cases/process-parameters-vue.png')" alt="ZK Desktop" width="800px">
+<img :src="$withBase('/images/use-cases/process-parameters-vue.png')" alt="ZK Desktop" width="100%">
 
 
 ### Validaciones Dinámicas
@@ -137,13 +137,13 @@ Para los campos de seleccionables (Lista, Tabla y Tabla Directa), deben filtrars
 4. Listar los valores del campo **Cuenta Bancaria Para** y verificar que el valor seleccionado en el campo anterior se excluye del resultado.
 
 ##### Versión ZK:
-<video width="800px" controls>
+<video width="100%" controls>
   <source type="video/mp4" :src="$withBase('/images/use-cases/process-dynamic-validation-zk.mp4')">
   Your browser does not support the mp4 video tag.
 </video>
 
 ##### Versión Vue:
-<video width="800px" controls>
+<video width="100%" controls>
   <source type="video/mp4" :src="$withBase('/images/use-cases/process-dynamic-validation-vue.mp4')">
   Your browser does not support the mp4 video tag.
 </video>
@@ -159,12 +159,12 @@ Para los campos de seleccionables (Lista, Tabla y Tabla Directa), deben filtrars
 ##### Versión ZK:
 1. Abrir el proceso **Transferencia Bancaria**.
 2. Los campos obligatorios muestran con un asterisco (*) rojo al lado derecho de su nombre.
-<img :src="$withBase('/images/use-cases/process-mandatory-zk.png')" alt="ZK Desktop" width="800px">
+<img :src="$withBase('/images/use-cases/process-mandatory-zk.png')" alt="ZK Desktop" width="100%">
 
 ##### Versión Vue:
 1. Abrir el proceso **Transferencia Bancaria**.
 2. Los campos obligatorios muestran con un asterisco (*) rojo al lado derecho de su nombre, y aquellos obligatorios vacios resaltan con un borde rojo sobre el campo.
-<img :src="$withBase('/images/use-cases/process-mandatory-vue.png')" alt="ZK Desktop" width="800px">
+<img :src="$withBase('/images/use-cases/process-mandatory-vue.png')" alt="ZK Desktop" width="100%">
 
 
 <!-- ### Solo Lectura -->
@@ -179,7 +179,7 @@ Manejar valor por defecto para los distintos tipos de parámetros.
 2. Hacer clic contrario en el valor del parámetro y seleccionar **Valor de Preferencia**.
 3. Observe que el parámetro **Tipo de Pago** tiene valor por defecto (A = Deposito Directo).
 
-<video width="800px" controls>
+<video width="100%" controls>
   <source type="video/mp4" :src="$withBase('/images/use-cases/process-default-value-zk.mp4')">
   Your browser does not support the mp4 video tag.
 </video>
@@ -189,7 +189,7 @@ Manejar valor por defecto para los distintos tipos de parámetros.
 2. Hacer clic en el nombre del parámetro y seleccionar **Información**.
 3. Observe que el parámetro **Fecha de Estado de Cuenta** y parámetro **Tipo de Pago** tienen valores por defectos y debidamente establecidos en los parámetros.
 
-<video width="800px" controls>
+<video width="100%" controls>
   <source type="video/mp4" :src="$withBase('/images/use-cases/process-default-value-vue.mp4')">
   Your browser does not support the mp4 video tag.
 </video>
@@ -207,7 +207,7 @@ Se deben asegurar las siguientes validaciones para poder ejecutar un proceso:
 * Si es proceso asociado a una ventana no permite ejecutarse en un nuevo registro.
 * Si es proceso asociado a una consulta inteligente debe tener minímo una fila selecionada.
 
-<video width="800px" controls>
+<video width="100%" controls>
   <source type="video/mp4" :src="$withBase('/images/use-cases/process-validate-mandatory-vue.mp4')">
   Your browser does not support the mp4 video tag.
 </video>
@@ -223,7 +223,7 @@ Se deben asegurar las siguientes validaciones para poder ejecutar un proceso:
 ### Cierre del Proceso al Ejecutarse
 Al comenzar la ejecución de un proceso, debe cerrar la vista actual.
 
-<video width="800px" controls>
+<video width="100%" controls>
   <source type="video/mp4" :src="$withBase('/images/use-cases/process-run-vue.mp4')">
   Your browser does not support the mp4 video tag.
 </video>
@@ -231,4 +231,4 @@ Al comenzar la ejecución de un proceso, debe cerrar la vista actual.
 ### Salida
 La salida es visuble al culminar la ejecucion del proceso, como notificación, sin embargo puede visualizarse en el historico de procesos.
 
-<img :src="$withBase('/images/use-cases/process-log-vue.png')" alt="Vue Desktop" width="800px">
+<img :src="$withBase('/images/use-cases/process-log-vue.png')" alt="Vue Desktop" width="100%">


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open documentation in mobile.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/168192605-78ea62d4-e7c0-4f6f-8c0f-dcdd79cc50ee.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/168192631-3964d4c6-47b7-45c9-9f90-d6e3989fe6d5.mp4

#### Additional context

https://solop-develop.github.io/frontend-core/guide/use-cases/process.html
