### PR TITLE
feat: Include submodule default theme.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "src/themes/frontend-default-theme"]
+	path = src/themes/frontend-default-theme
+	url = https://github.com/solop-develop/frontend-default-theme.git
+	branch = experimental


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

When cloning the repository for the first time, and trying to add the sub-module with the command
`git submodule add -b experimental https://github.com/solop-develop/frontend-default-theme.git src/themes/frontend-default-theme`

Appears the next message:
`fronted-default-theme already exists in the index.`

Therefore, to allow the sub-module to be added, the command had to be executed
`git clean -f -d`

#### Other relevant information
- Your OS: Linux Mint 20.3 x64.
- Web Browser: Mozilla Firefox 99.0
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

