### PR TITLE
feat: Notify when a report generates an error.

### DIFF
--- a/src/store/modules/ADempiere/reportManager.js
+++ b/src/store/modules/ADempiere/reportManager.js
@@ -132,7 +132,17 @@ const reportManager = {
           reportViewUuid
         })
           .then(runReportRepsonse => {
-            const { instanceUuid, output } = runReportRepsonse
+            const { instanceUuid, output, isError } = runReportRepsonse
+
+            if (isError) {
+              showNotification({
+                title: language.t('notifications.error'),
+                message: reportDefinition.name,
+                summary: runReportRepsonse.summary,
+                type: 'error'
+              })
+              console.warn(`Error running the process. ${runReportRepsonse.summary}.`)
+            }
 
             let link = {
               href: undefined,
@@ -218,7 +228,17 @@ const reportManager = {
           parametersList
         })
           .then(runReportRepsonse => {
-            const { instanceUuid, output } = runReportRepsonse
+            const { instanceUuid, output, isError } = runReportRepsonse
+
+            if (isError) {
+              showNotification({
+                title: language.t('notifications.error'),
+                message: reportDefinition.name,
+                summary: runReportRepsonse.summary,
+                type: 'error'
+              })
+              console.warn(`Error running the report. ${runReportRepsonse.summary}.`)
+            }
 
             let link = {
               href: undefined,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Show `Open Items` report.
2. Click in generate with default values and format (html).

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/168859569-e28d0f53-cb0c-4412-8695-13358fece7e2.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/168859562-ddd0011a-4cea-4c55-9d87-a3ebcea1bd51.mp4


#### Expected behavior
It is expected that if an error is generated notify the user, since the flow is that the report is generated in the background taking sometimes a considerable amount of time.


#### Other relevant information
- Your OS: Linux Mint 20.3 x64.
- Web Browser: Mozilla Firefox 99.0
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

