### PR TITLE
feat: Generated report with last parameters.

### DIFF
--- a/src/layout/components/Sidebar/SidebarItem.vue
+++ b/src/layout/components/Sidebar/SidebarItem.vue
@@ -133,9 +133,10 @@ export default {
         } = view.meta
 
         if (panelType !== 'window') {
-          const setDefaul = this.$store._actions[`set${capitalize(panelType)}DefaultValues`]
-          if (setDefaul) {
-            this.$store.dispatch(`set${capitalize(panelType)}DefaultValues`, {
+          const defaultValuesDispatch = `set${capitalize(panelType)}DefaultValues`
+          const isExists = this.$store._actions[defaultValuesDispatch]
+          if (isExists) {
+            this.$store.dispatch(defaultValuesDispatch, {
               parentUuid,
               containerUuid,
               panelType,

--- a/src/router/modules/ADempiere/staticRoutes.js
+++ b/src/router/modules/ADempiere/staticRoutes.js
@@ -62,7 +62,8 @@ const staticRoutes = [
         name: 'Report Viewer',
         meta: {
           title: language.t('route.reportViewer'),
-          reportFormat: ''
+          type: 'report',
+          reportType: ''
         }
       }
     ]

--- a/src/store/modules/ADempiere/dictionary/report/actions.js
+++ b/src/store/modules/ADempiere/dictionary/report/actions.js
@@ -128,9 +128,9 @@ export default {
           actionName: 'runReportAs',
           uuid: null,
           runReportAs: ({ root, containerUuid }) => {
-            root.$store.dispatch('startReport', {
+            root.$store.dispatch('buildReport', {
               containerUuid,
-              reportFormat: reportType.type
+              reportType: reportType.type
             })
           }
         })
@@ -189,7 +189,7 @@ export default {
           actionName: 'runReportAs',
           uuid: null,
           runReportAs: ({ root, containerUuid }) => {
-            root.$store.dispatch('startReport', {
+            root.$store.dispatch('buildReport', {
               containerUuid,
               reportViewUuid: reportView.reportViewUuid
             })
@@ -245,7 +245,7 @@ export default {
    * @param {string}  containerUuid
    * @param {array}  fieldsList
    */
-  setReportDefaultValues({ dispatch, getters }, {
+  setReportDefaultValues({ commit, dispatch, getters }, {
     containerUuid,
     fieldsList = []
   }) {
@@ -265,6 +265,11 @@ export default {
         containerUuid,
         isOverWriteParent: true,
         attributes: defaultAttributes
+      })
+
+      // clear last parameters with report generated
+      commit('setReportGenerated', {
+        containerUuid
       })
 
       resolve(defaultAttributes)

--- a/src/utils/ADempiere/dictionary/report.js
+++ b/src/utils/ADempiere/dictionary/report.js
@@ -46,6 +46,11 @@ export const reportFormatsList = [
   'xml'
 ]
 
+/**
+ * Default report type to generate
+ */
+export const DEFAULT_REPORT_TYPE = 'pdf'
+
 export const runReport = {
   name: language.t('actionMenu.generateReport'),
   description: language.t('actionMenu.generateDefaultReport'),
@@ -59,7 +64,7 @@ export const runReport = {
   actionName: 'runReport',
   uuid: null,
   runReport: ({ containerUuid }) => {
-    store.dispatch('startReport', {
+    store.dispatch('buildReport', {
       containerUuid
     })
   }
@@ -77,7 +82,7 @@ export const runReportAs = {
   uuid: null,
   childs: [],
   runReportAs: ({ containerUuid }) => {
-    store.dispatch('startReport', {
+    store.dispatch('buildReport', {
       containerUuid
     })
   }
@@ -95,7 +100,7 @@ export const runReportAsPrintFormat = {
   uuid: null,
   childs: [],
   runReportAsPrintFormat: ({ containerUuid }) => {
-    store.dispatch('startReport', {
+    store.dispatch('buildReport', {
       containerUuid
     })
   }
@@ -113,7 +118,7 @@ export const runReportAsView = {
   uuid: null,
   childs: [],
   runReportAsView: ({ containerUuid }) => {
-    store.dispatch('startReport', {
+    store.dispatch('buildReport', {
       containerUuid
     })
   }

--- a/src/utils/ADempiere/resource.js
+++ b/src/utils/ADempiere/resource.js
@@ -19,6 +19,16 @@
 // Please add the necessary functions here:
 import { config } from '@/utils/ADempiere/config'
 import { getToken } from '@/utils/auth'
+
+/**
+ * Extract extension file from file name
+ * @param {string} fileName
+ * @returns
+ */
+export function getExtensionFromFile(fileName) {
+  return fileName.split('.').pop()
+}
+
 // Merge two arrays and return merged array
 export function mergeByteArray(currentArray, arrayToMerge) {
   const mergedArray = new currentArray.constructor(currentArray.length + arrayToMerge.length)

--- a/src/views/ADempiere/ReportViewer/index.vue
+++ b/src/views/ADempiere/ReportViewer/index.vue
@@ -37,7 +37,7 @@
           />
 
           <file-render
-            :format="reportFormat"
+            :format="reportType"
             :content="reportContent"
             :src="link.href"
             :mime-type="getStoredReportOutput.mimeType"
@@ -79,6 +79,8 @@ import TitleAndHelp from '@theme/components/ADempiere/TitleAndHelp/index.vue'
 import { convertObjectToKeyValue } from '@/utils/ADempiere/valueFormat.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { showNotification } from '@/utils/ADempiere/notification.js'
+import { getExtensionFromFile } from '@/utils/ADempiere/resource.js'
+import { DEFAULT_REPORT_TYPE } from '@/utils/ADempiere/dictionary/report.js'
 
 export default defineComponent({
   name: 'ReportViewer',
@@ -95,7 +97,7 @@ export default defineComponent({
     const reportUuid = root.$route.params.reportUuid
     const { containerManager, actionsManager, storedReportDefinition } = mixinReport(reportUuid)
     const isLoading = ref(false)
-    const reportFormat = ref('html')
+    const reportType = ref(DEFAULT_REPORT_TYPE)
     const reportContent = ref('')
 
     const getStoredReportOutput = computed(() => {
@@ -108,9 +110,9 @@ export default defineComponent({
 
     function displayReport(reportOutput) {
       if (!reportOutput.isError) {
-        const { output, reportType } = reportOutput
+        const { output, reportType: format } = reportOutput
 
-        reportFormat.value = reportType
+        reportType.value = format
         reportContent.value = output
 
         isLoading.value = true
@@ -178,10 +180,10 @@ export default defineComponent({
                   object: parameters
                 })
 
-                const reportType = fileName.split('.').pop()
-                store.dispatch('getReportOutputFromServer', {
+                const reportFormat = getExtensionFromFile(fileName)
+                store.dispatch('buildReport', {
                   uuid: reportUuid,
-                  reportType,
+                  reportType: reportFormat,
                   reportName: fileName,
                   tableName: root.$route.params.tableName,
                   parametersList,
@@ -212,13 +214,13 @@ export default defineComponent({
 
     onMounted(() => {
       getReport()
-      root.$route.meta.reportFormat = reportFormat.value
+      root.$route.meta.reportType = reportType.value
     })
 
     return {
       reportUuid,
       isLoading,
-      reportFormat,
+      reportType,
       reportContent,
       actionsManager,
       relationsManager,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Shipment Details` report.
2. Generate as `html` report type.
3. Generate changes in the report view

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/168943738-2ce2f937-3d13-4601-a9ee-00190b760211.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/168943740-fb03a648-e70d-4660-9a9f-265f613a3bf4.mp4

#### Expected behavior
If only the report view (or print format) is changed, it should keep the same report type (pdf for this case) or extension from where it is being generated, unless the report type is explicitly changed.

#### Other relevant information
- Your OS: Linux Mint 20.3 x64.
- Web Browser: Mozilla Firefox 99.0
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.


