### PR TITLE
feat: Displayed report associated in button field.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/report/actions.js
+++ b/src/store/modules/ADempiere/dictionary/report/actions.js
@@ -48,7 +48,7 @@ export default {
    * Get report dictionary definition
    * @param {string} uuid of dictionary
    */
-  getReportDefinitionFromServer({ dispatch }, {
+  getReportDefinitionFromServer({ dispatch, getters }, {
     uuid
   }) {
     return new Promise((resolve, reject) => {
@@ -78,23 +78,27 @@ export default {
 
           resolve(reportDefinition)
 
-          dispatch('setModalDialog', {
-            containerUuid: uuid,
-            title: reportDefinition.name,
-            doneMethod: () => {
-              dispatch('startReport', {
-                containerUuid: uuid
-              })
-            },
-            loadData: () => {
-              return dispatch('getProcessDefinitionFromServer', {
-                uuid: uuid
-              })
-            },
-            // TODO: Change to string and import dynamic in component
-            componentPath: () => import('@theme/components/ADempiere/PanelDefinition/index.vue'),
-            isShowed: false
-          })
+          // exist dialog if is process associated
+          const storedModalDialog = getters.getModalDialogManager({ containerUuid: uuid })
+          if (isEmptyValue(storedModalDialog)) {
+            dispatch('setModalDialog', {
+              containerUuid: uuid,
+              title: reportDefinition.name,
+              doneMethod: () => {
+                dispatch('startReport', {
+                  containerUuid: uuid
+                })
+              },
+              loadData: () => {
+                return dispatch('getReportDefinitionFromServer', {
+                  uuid: uuid
+                })
+              },
+              // TODO: Change to string and import dynamic in component
+              componentPath: () => import('@theme/components/ADempiere/PanelDefinition/index.vue'),
+              isShowed: false
+            })
+          }
         })
         .catch(error => {
           reject(error)

--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -81,6 +81,20 @@ export default {
   },
 
   /**
+   * Field with process associated
+   * @param {string} windowUuid or parentUuid
+   * @param {string} tabUuid or containerUuid
+   * @param {string} processUuid process associated
+   * @returns {object}
+   */
+  getStoredFieldFromProcess: (state, getters) => ({ windowUuid, tabUuid, processUuid }) => {
+    return getters.getStoredFieldsFromTab(windowUuid, tabUuid)
+      .find(field => {
+        return field.process && field.process.uuid === processUuid
+      })
+  },
+
+  /**
    * Determinate if panel is ready to send, all fields mandatory and displayed with values
    * @param {string}  containerUuid
    * @param {object}  row, data to compare if is table

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import lang from '@/lang'
+import language from '@/lang'
 import store from '@/store'
 
 // utils and helpers methods
@@ -81,12 +81,16 @@ export function isReadOnlyColumn({ isReadOnly }) {
  */
 export const createNewRecord = {
   sequence: 0,
-  name: lang.t('actionMenu.createNewRecord'),
+  name: language.t('actionMenu.createNewRecord'),
   type: 'setDefaultValues',
   enabled: ({ parentUuid, containerUuid }) => {
-    return !isEmptyValue(
-      store.getters.getUuidOfContainer(containerUuid)
-    )
+    const tab = store.getters.getStoredTab(parentUuid, containerUuid)
+    if (tab.isInsertRecord) {
+      const recordUuid = store.getters.getUuidOfContainer(containerUuid)
+      return !isEmptyValue(recordUuid)
+    }
+
+    return false
   },
   svg: false,
   icon: 'el-icon-circle-plus-outline',
@@ -101,7 +105,7 @@ export const createNewRecord = {
 
 export const undoChange = {
   sequence: 0,
-  name: lang.t('actionMenu.createNewRecord'),
+  name: language.t('actionMenu.createNewRecord'),
   type: 'undoModifyData',
   enabled: ({ parentUuid, containerUuid }) => {
     return isEmptyValue(
@@ -116,14 +120,18 @@ export const undoChange = {
 }
 
 /**
- * Delete record (entity) with record
+ * Delete record (entity)
  */
 export const deleteRecord = {
-  name: lang.t('actionMenu.deleteRecord'),
+  name: language.t('actionMenu.deleteRecord'),
   enabled: ({ parentUuid, containerUuid }) => {
-    return !isEmptyValue(
-      store.getters.getUuidOfContainer(containerUuid)
-    )
+    const tab = store.getters.getStoredTab(parentUuid, containerUuid)
+    if (tab.isInsertRecord && tab.isDeleteable) {
+      const recordUuid = store.getters.getUuidOfContainer(containerUuid)
+      return !isEmptyValue(recordUuid)
+    }
+
+    return false
   },
   svg: false,
   icon: 'el-icon-delete',
@@ -138,13 +146,13 @@ export const deleteRecord = {
     })
       .then(() => {
         showMessage({
-          message: lang.t('recordManager.deleteRecordSuccessful'),
+          message: language.t('recordManager.deleteRecordSuccessful'),
           type: 'success'
         })
       })
       .catch(error => {
         showMessage({
-          message: lang.t('recordManager.deleteRecordError'),
+          message: language.t('recordManager.deleteRecordError'),
           type: 'error'
         })
         console.warn(`Delete Entity - Error ${error.message}, Code: ${error.code}.`)
@@ -152,12 +160,14 @@ export const deleteRecord = {
   }
 }
 
+/**
+ * Run process associated on table or button field
+ */
 export const runProcessOfWindow = {
-  name: lang.t('actionMenu.runProcess'),
+  name: language.t('actionMenu.runProcess'),
   enabled: ({ parentUuid, containerUuid }) => {
-    return !isEmptyValue(
-      store.getters.getUuidOfContainer(containerUuid)
-    )
+    const recordUuid = store.getters.getUuidOfContainer(containerUuid)
+    return !isEmptyValue(recordUuid)
   },
   svg: false,
   icon: 'el-icon-setting',
@@ -171,12 +181,14 @@ export const runProcessOfWindow = {
   }
 }
 
+/**
+ * Generate report associated on table or button field
+ */
 export const generateReportOfWindow = {
-  name: lang.t('actionMenu.generateReport'),
+  name: language.t('actionMenu.generateReport'),
   enabled: ({ parentUuid, containerUuid }) => {
-    return !isEmptyValue(
-      store.getters.getUuidOfContainer(containerUuid)
-    )
+    const recordUuid = store.getters.getUuidOfContainer(containerUuid)
+    return !isEmptyValue(recordUuid)
   },
   svg: false,
   icon: 'el-icon-document',
@@ -191,7 +203,7 @@ export const generateReportOfWindow = {
 }
 
 export const refreshRecords = {
-  name: lang.t('actionMenu.refreshRecords'),
+  name: language.t('actionMenu.refreshRecords'),
   enabled: () => {
     return true
   },
@@ -208,7 +220,7 @@ export const refreshRecords = {
 }
 
 export const lockRecord = {
-  name: lang.t('actionMenu.refreshRecords'),
+  name: language.t('actionMenu.refreshRecords'),
   type: 'lockRecord',
   enabled: ({ parentUuid, containerUuid }) => {
     return !isEmptyValue(
@@ -223,7 +235,7 @@ export const lockRecord = {
 }
 
 export const unlockRecord = {
-  name: lang.t('actionMenu.refreshRecords'),
+  name: language.t('actionMenu.refreshRecords'),
   type: 'unlockRecord',
   enabled: ({ parentUuid, containerUuid }) => {
     return !isEmptyValue(
@@ -238,7 +250,7 @@ export const unlockRecord = {
 }
 
 export const recordAccess = {
-  name: lang.t('actionMenu.refreshRecords'),
+  name: language.t('actionMenu.refreshRecords'),
   enabled: ({ parentUuid, containerUuid }) => {
     return !isEmptyValue(
       store.getters.getUuidOfContainer(containerUuid)

--- a/src/views/ADempiere/Window/MultiTabWindow.vue
+++ b/src/views/ADempiere/Window/MultiTabWindow.vue
@@ -59,7 +59,7 @@
 
 <script>
 import { defineComponent, computed, ref } from '@vue/composition-api'
-import lang from '@/lang'
+import language from '@/lang'
 import router from '@/router'
 import store from '@/store'
 
@@ -113,6 +113,10 @@ export default defineComponent({
 
     const showRecordAccess = computed(() => {
       return store.getters.getShowPanelRecordAccess
+    })
+
+    const currentTabUuid = computed(() => {
+      return store.getters.getCurrentTab(props.windowMetadata.uuid).uuid
     })
 
     const containerManager = {
@@ -227,22 +231,24 @@ export default defineComponent({
       }
     }
 
-    const actionsManager = ref({
-      parentUuid: props.windowMetadata.uuid,
-      containerUuid: props.windowMetadata.currentTabUuid,
+    const actionsManager = computed(() => {
+      return {
+        parentUuid: props.windowMetadata.uuid,
+        containerUuid: currentTabUuid.value,
 
-      defaultActionName: lang.t('actionMenu.createNewRecord'),
-      tableName: store.getters.getTableName(props.windowMetadata.uuid, props.windowMetadata.currentTabUuid),
-      getActionList: () => {
-        return store.getters.getStoredActionsMenu({
-          containerUuid: props.windowMetadata.currentTabUuid
-        })
+        defaultActionName: language.t('actionMenu.createNewRecord'),
+        tableName: store.getters.getTableName(props.windowMetadata.uuid, currentTabUuid.value),
+        getActionList: () => {
+          return store.getters.getStoredActionsMenu({
+            containerUuid: currentTabUuid.value
+          })
+        }
       }
     })
 
     const referencesManager = ref({
       getTableName: () => {
-        const tabUuid = props.windowMetadata.currentTabUuid
+        const tabUuid = currentTabUuid.value
         const windowUuid = props.windowMetadata.uuid
 
         return store.getters.getTableName(windowUuid, tabUuid)
@@ -257,7 +263,7 @@ export default defineComponent({
     }
 
     return {
-      currentTabUuid: props.windowMetadata.currentTabUuid,
+      currentTabUuid,
       actionsManager,
       allTabsList,
       referencesManager,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Business Partner` window.
2. Select `Customer` tab.
3. List actions menu.
4. Change value of field `Is Customer`.
5. Select `Open Items` report on action menu.

#### Screenshot or Gif

Vue Version:

https://user-images.githubusercontent.com/20288327/169158329-08b5b324-2974-447d-a6a8-fb36af0fecc3.mp4

https://user-images.githubusercontent.com/20288327/169158331-ad34e676-2d0a-467d-a7f5-0e4ec4c44681.mp4

Zk Version:

https://user-images.githubusercontent.com/20288327/169158335-5e784af6-c721-40e6-a471-ce7f0d28e3c3.mp4


#### Other relevant information
- Your OS: Linux Mint 20.3 x64.
- Web Browser: Mozilla Firefox 99.0
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Note that the display logic of the action menu process is the same as the button field that has the process associated with it.
