### PR TITLE
feat: Add open Smart Browser associated.

### DIFF
--- a/src/api/ADempiere/browser.js
+++ b/src/api/ADempiere/browser.js
@@ -16,6 +16,7 @@
 
 // Get Instance for connection
 import { request } from '@/utils/ADempiere/request'
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 
 /**
  * Request a browser search
@@ -50,6 +51,17 @@ export function requestBrowserSearch({
     }
   })
 
+  // context attributes
+  let contextAttributes = []
+  if (!isEmptyValue(contextAttributesList)) {
+    contextAttributes = contextAttributesList.map(attribute => {
+      return {
+        key: attribute.columnName,
+        value: attribute.value
+      }
+    })
+  }
+
   return request({
     url: '/user-interface/smart-browser/browser-items',
     method: 'post',
@@ -60,7 +72,7 @@ export function requestBrowserSearch({
       // DSL Query
       filters,
       // Custom Query
-      context_attributes: contextAttributesList
+      context_attributes: contextAttributes
     },
     params: {
       // Page Data

--- a/src/lang/ADempiere/en/actionMenu.js
+++ b/src/lang/ADempiere/en/actionMenu.js
@@ -36,6 +36,7 @@ const actionMenu = {
   reportViews: 'Report Views',
   generateWithReportView: 'Change report view to generate',
   // browser
+  openSmartBrowser: 'Open Smart Browser',
   exportSelectedRecords: 'Exportar Registros Seleccionados',
   // relations
   relations: 'Relations',

--- a/src/lang/ADempiere/en/index.js
+++ b/src/lang/ADempiere/en/index.js
@@ -4,6 +4,8 @@ import extensionFile from './extensionFile'
 import fieldDisplayOptions from './fieldDisplayOptions'
 import fieldOptions from './fieldOptions'
 import recordManager from './recordManager'
+import route from './route'
+import smartBrowser from './smartBrowser'
 import window from './window'
 
 export default {
@@ -12,27 +14,10 @@ export default {
   fieldDisplayOptions,
   fieldOptions,
   recordManager,
+  route,
+  smartBrowser,
 
   language: 'Language',
-  route: {
-    dashboard: 'Dashboard',
-    calendar: 'Calendar',
-    documentation: 'Documentation',
-    guide: 'Guide',
-    forgotPassword: 'Forgot Password?',
-    userEnrollment: 'Check in',
-    page401: '401',
-    page404: '404',
-    profile: 'Profile',
-    ProcessActivity: 'Process Logs',
-    withoutLog: 'No Error Log Found',
-    ProductInfo: 'Product Information',
-    role: 'Role',
-    organization: 'Organization',
-    warehouse: 'Warehouse',
-    reportViewer: 'Report Viewer',
-    PriceChecking: 'Price checking'
-  },
   notifications: {
     // simplex
     completed: 'Completed',

--- a/src/lang/ADempiere/en/route.js
+++ b/src/lang/ADempiere/en/route.js
@@ -1,0 +1,38 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const route = {
+  dashboard: 'Dashboard',
+  calendar: 'Calendar',
+  documentation: 'Documentation',
+  guide: 'Guide',
+  forgotPassword: 'Forgot Password?',
+  userEnrollment: 'Check in',
+  page401: '401',
+  page404: '404',
+  profile: 'Profile',
+  ProcessActivity: 'Process Logs',
+  withoutLog: 'No Error Log Found',
+  ProductInfo: 'Product Information',
+  role: 'Role',
+  organization: 'Organization',
+  warehouse: 'Warehouse',
+  reportViewer: 'Report Viewer',
+  smartBrowser: 'Smart Brower',
+  PriceChecking: 'Price checking'
+}
+
+export default route

--- a/src/lang/ADempiere/en/smartBrowser.js
+++ b/src/lang/ADempiere/en/smartBrowser.js
@@ -1,0 +1,23 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const smartBrowser = {
+  smartBrowser: 'Smart Browser',
+  // dictionary
+  dictionaryError: 'Error loading smart browser definition'
+}
+
+export default smartBrowser

--- a/src/lang/ADempiere/es/actionMenu.js
+++ b/src/lang/ADempiere/es/actionMenu.js
@@ -36,6 +36,7 @@ const actionMenu = {
   reportViews: 'Vistas de Reporte',
   generateWithReportView: 'Cambiar vista de reporte para generar',
   // browser
+  openSmartBrowser: 'Abrir Consulta Inteligente',
   exportSelectedRecords: 'Exportar Registros Seleccionados',
   delete: 'Eliminar',
   // relations

--- a/src/lang/ADempiere/es/index.js
+++ b/src/lang/ADempiere/es/index.js
@@ -4,6 +4,8 @@ import extensionFile from './extensionFile'
 import fieldDisplayOptions from './fieldDisplayOptions'
 import fieldOptions from './fieldOptions'
 import recordManager from './recordManager'
+import route from './route'
+import smartBrowser from './smartBrowser'
 import window from './window'
 
 export default {
@@ -12,27 +14,10 @@ export default {
   fieldDisplayOptions,
   fieldOptions,
   recordManager,
+  route,
+  smartBrowser,
 
   language: 'Idioma',
-  route: {
-    dashboard: 'Panel de control',
-    documentation: 'Documentación',
-    calendar: 'Calendario',
-    forgotPassword: '¿Olvidó su Contraseña?',
-    userEnrollment: 'Registrarse',
-    guide: 'Guía',
-    page401: '401',
-    page404: '404',
-    profile: 'Perfil',
-    ProcessActivity: 'Histórico Procesos',
-    withoutLog: 'No se Encontró Registro de Error ',
-    ProductInfo: 'Información de Producto',
-    role: 'Rol',
-    organization: 'Organización',
-    warehouse: 'Almacén',
-    reportViewer: 'Visor de Reportes',
-    PriceChecking: 'Consulta del precio'
-  },
   notifications: {
     // simplex
     completed: 'Completado',

--- a/src/lang/ADempiere/es/route.js
+++ b/src/lang/ADempiere/es/route.js
@@ -1,0 +1,38 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const route = {
+  dashboard: 'Panel de control',
+  documentation: 'Documentación',
+  calendar: 'Calendario',
+  forgotPassword: '¿Olvidó su Contraseña?',
+  userEnrollment: 'Registrarse',
+  guide: 'Guía',
+  page401: '401',
+  page404: '404',
+  profile: 'Perfil',
+  ProcessActivity: 'Histórico Procesos',
+  withoutLog: 'No se Encontró Registro de Error ',
+  ProductInfo: 'Información de Producto',
+  role: 'Rol',
+  organization: 'Organización',
+  warehouse: 'Almacén',
+  reportViewer: 'Visor de Reportes',
+  smartBrowser: 'Consulta Inteligente',
+  PriceChecking: 'Consulta del precio'
+}
+
+export default route

--- a/src/lang/ADempiere/es/smartBrowser.js
+++ b/src/lang/ADempiere/es/smartBrowser.js
@@ -1,0 +1,23 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const smartBrowser = {
+  smartBrowser: 'Consulta Inteligente',
+  // dictionary
+  dictionaryError: 'Error al cargar la definición de la consulta inteligente'
+}
+
+export default smartBrowser

--- a/src/router/modules/ADempiere/staticRoutes.js
+++ b/src/router/modules/ADempiere/staticRoutes.js
@@ -70,6 +70,25 @@ const staticRoutes = [
   },
 
   {
+    path: '/browser',
+    component: Layout,
+    hidden: true,
+    redirect: 'browser/:browserId/:browserUuid?',
+    children: [
+      {
+        path: ':browserId/:browserUuid?',
+        component: () => import('@/views/ADempiere/Browser'),
+        name: 'Smart Browser',
+        meta: {
+          icon: 'search',
+          title: language.t('route.smartBrowser'),
+          type: 'browser'
+        }
+      }
+    ]
+  },
+
+  {
     path: '/PriceChecking',
     component: Layout,
     hidden: true,

--- a/src/store/modules/ADempiere/browserManager.js
+++ b/src/store/modules/ADempiere/browserManager.js
@@ -222,6 +222,7 @@ const browserControl = {
               containerUuid,
               isLoaded: true
             })
+            resolve([])
 
             showMessage({
               title: language.t('notifications.error'),

--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -28,6 +28,7 @@ import {
   deleteRecord,
   runProcessOfWindow,
   generateReportOfWindow,
+  openBrowserAssociated,
   refreshRecords
 } from '@/utils/ADempiere/dictionary/window.js'
 import {
@@ -82,7 +83,9 @@ export default {
       tabDefinition.processes.forEach(process => {
         let defaultAction = {}
         if (process.isReport) {
-          defaultAction = generateReportOfWindow
+          defaultAction = {
+            ...generateReportOfWindow
+          }
           dispatch('setModalDialog', {
             containerUuid: process.uuid,
             title: process.name,
@@ -104,8 +107,14 @@ export default {
             componentPath: () => import('@theme/components/ADempiere/PanelDefinition/index.vue'),
             isShowed: false
           })
+        } else if (!isEmptyValue(process.browserUuid)) {
+          defaultAction = {
+            ...openBrowserAssociated
+          }
         } else {
-          defaultAction = runProcessOfWindow
+          defaultAction = {
+            ...runProcessOfWindow
+          }
           dispatch('setModalDialog', {
             containerUuid: process.uuid,
             title: process.name,

--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -81,6 +81,23 @@ export default {
   },
 
   /**
+   * Process associated on tab
+   * @param {string} windowUuid or parentUuid
+   * @param {string} tabUuid or containerUuid
+   * @param {string} processUuid process associated
+   * @returns {object}
+   */
+  getStoredProcessFromTab: (state, getters) => ({ windowUuid, tabUuid, processUuid }) => {
+    const storedTab = getters.getStoredTab(windowUuid, tabUuid)
+
+    return storedTab
+      .processes
+      .find(process => {
+        return process.uuid === processUuid
+      })
+  },
+
+  /**
    * Field with process associated
    * @param {string} windowUuid or parentUuid
    * @param {string} tabUuid or containerUuid

--- a/src/store/modules/ADempiere/fieldValue.js
+++ b/src/store/modules/ADempiere/fieldValue.js
@@ -255,7 +255,6 @@ const value = {
      * uuid), from a view (container)
      * @param {string} parentUuid
      * @param {string} containerUuid
-     * @param {string} format array|object|pairs|map
      * @returns {object|array}
      */
     getValuesViewType: (state) => ({

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import language from '@/lang'
+import router from '@/router'
 import store from '@/store'
 
 // utils and helpers methods
@@ -190,8 +191,8 @@ export const generateReportOfWindow = {
     const recordUuid = store.getters.getUuidOfContainer(containerUuid)
     return !isEmptyValue(recordUuid)
   },
-  svg: false,
-  icon: 'el-icon-document',
+  isSvgIcon: true,
+  icon: 'skill',
   actionName: 'generateReportOfWindow',
   generateReportOfWindow: ({ parentUuid, containerUuid, uuid }) => {
     store.commit('setSelectProcessWindows', uuid)
@@ -199,6 +200,38 @@ export const generateReportOfWindow = {
       containerUuid: uuid,
       isShowed: true
     })
+  }
+}
+
+/**
+ * Open Smart Browser Associated in Process
+ */
+export const openBrowserAssociated = {
+  name: language.t('actionMenu.openSmartBrowser'),
+  enabled: ({ parentUuid, containerUuid }) => {
+    const recordUuid = store.getters.getUuidOfContainer(containerUuid)
+    return !isEmptyValue(recordUuid)
+  },
+  isSvgIcon: true,
+  icon: 'search',
+  actionName: 'openBrowserAssociated',
+  openBrowserAssociated: function({ parentUuid, containerUuid, uuid }) {
+    const process = store.getters.getStoredProcessFromTab({
+      windowUuid: parentUuid,
+      tabUuid: containerUuid,
+      processUuid: uuid
+    })
+
+    router.push({
+      name: 'Smart Browser',
+      params: {
+        browserId: 0,
+        browserUuid: process.browserUuid
+      },
+      query: {
+        parentUuid
+      }
+    }, () => {})
   }
 }
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Payment Selection` window.
2. Expand actions menu.
3. Select `Create Payment From Selection` smart browser.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/170128727-09915159-bff6-44ec-a7b4-3044327fb51c.mp4



#### Other relevant information
- Your OS: Linux Mint 20.3 x64.
- Web Browser: Mozilla Firefox 99.0
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
These smart browsers are associated to a process and these in turn are associated to a table/button.

For these cases the Smart Browser does not exist in the menu, therefore it is loaded in the route in the following way

`browser/browserId/browserUuid?parentUuid`

`browser`: Locates the view of the component
`browserId`: This parameter must have the id of the smart browser, by default in 0.
`browserUuid`: This parameter is the uuid of the smart browser to get information.
`parrentUuid`: This parameter indicates the window from which the context to be set in the smart browser was used.

Example:

http://0.0.0.0:9527/#/browser/0/8aaeea60-fb40-11e8-a479-7a0060f0aa01?parentUuid=a5210e14-fb40-11e8-a479-7a0060f0aa01

