### PR TITLE
fix: SB Dynamic validation with element name.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/browser/getters.js
+++ b/src/store/modules/ADempiere/dictionary/browser/getters.js
@@ -35,6 +35,19 @@ export default {
     return undefined
   },
 
+  getStoredColumnsFromBrowser: (state, getters) => (browserUuid) => {
+    const browser = getters.getStoredBrowser(browserUuid)
+    const columnsList = []
+    if (!isEmptyValue(browser)) {
+      browser.fieldsList.forEach(field => {
+        columnsList.push(field.columnName)
+        columnsList.push(field.elementName)
+      })
+      return columnsList
+    }
+    return columnsList
+  },
+
   getProcessOfBrowser: (state, getters, rootState, rootGetters) => (browserUuid) => {
     const { process } = getters.getStoredBrowser(browserUuid)
 

--- a/src/store/modules/ADempiere/lookupManager.js
+++ b/src/store/modules/ADempiere/lookupManager.js
@@ -69,6 +69,8 @@ const lookupManager = {
      * @param {string} tableName
      * @param {string} directQuery
      * @param {string|number} value identifier or key
+     * @param {boolean} isAddBlankValue add blanck value option in fist element on list
+     * @param {string|number} blankValue value to add in empty option ("", -1, null, undefined)
      */
     getLookupListFromServer({ commit, rootGetters }, {
       isAddBlankValue = false,
@@ -132,6 +134,8 @@ const lookupManager = {
                 })
               }
             })
+
+            // add blanck value option in fist element on list
             if (isAddBlankValue) {
               optionsList.unshift({
                 displayedValue: ' ',

--- a/src/store/modules/ADempiere/panel/actions.js
+++ b/src/store/modules/ADempiere/panel/actions.js
@@ -441,7 +441,8 @@ const actions = {
       }
     }
     const dependentsList = fieldsList.filter(fieldItem => {
-      return field.dependentFieldsList.includes(fieldItem.columnName)
+      return field.dependentFieldsList.includes(fieldItem.columnName) ||
+        field.dependentFieldsList.includes(fieldItem.elementName)
     })
 
     //  Iterate for change logic
@@ -505,6 +506,15 @@ const actions = {
             columnName: fieldDependent.columnName,
             value: newValue
           })
+          // update values for field on elememnt name of column
+          if (fieldDependent.columnName !== fieldDependent.elementName) {
+            commit('updateValueOfField', {
+              parentUuid,
+              containerUuid,
+              columnName: fieldDependent.elementName,
+              value: newValue
+            })
+          }
         }
       }
 

--- a/src/utils/ADempiere/dictionary/browser.js
+++ b/src/utils/ADempiere/dictionary/browser.js
@@ -26,13 +26,13 @@ import { zoomIn } from '@/utils/ADempiere/coreUtils.js'
 /**
  * Is displayed field in panel query criteria
  */
-export function isDisplayedField({ displayType, isActive, isQueryCriteria, isDisplayedFromLogic }) {
+export function isDisplayedField({ displayType, isActive, isQueryCriteria, displayLogic, isDisplayedFromLogic }) {
   // button field not showed
   if (isHiddenField(displayType)) {
     return false
   }
 
-  return isActive && isQueryCriteria && isDisplayedFromLogic
+  return isActive && isQueryCriteria && (isEmptyValue(displayLogic) || isDisplayedFromLogic)
 }
 
 /**
@@ -145,7 +145,6 @@ export const runProcessOfBrowser = {
 /**
  * isDeleteable
  */
-
 export const runDeleteable = {
   name: language.t('actionMenu.delete'),
   enabled: ({ containerUuid, containerManager }) => {
@@ -202,6 +201,105 @@ export const zoomWindow = {
   zoomWindow: ({ uuid }) => {
     zoomIn({
       uuid
+    })
+  }
+}
+
+/**
+ * Manage the browser panel
+ */
+export const containerManager = {
+  getPanel({ containerUuid }) {
+    return store.getters.getStoredBrowser(containerUuid)
+  },
+  getFieldsList({ containerUuid }) {
+    return store.getters.getStoredFieldsFromBrowser(containerUuid)
+  },
+
+  actionPerformed({ field, value, valueTo, containerUuid }) {
+    return store.dispatch('browserActionPerformed', {
+      containerUuid,
+      field,
+      value,
+      valueTo
+    })
+  },
+
+  setDefaultValues: ({ parentUuid, containerUuid }) => {
+    store.dispatch('setBrowserDefaultValues', {
+      parentUuid,
+      containerUuid
+    })
+  },
+
+  /**
+   * Is displayed field in panel single record
+   */
+  isDisplayedField,
+
+  isMandatoryField,
+
+  isReadOnlyField,
+
+  changeFieldShowedFromUser({ containerUuid, fieldsShowed }) {
+    store.dispatch('changeBrowserFieldShowedFromUser', {
+      containerUuid,
+      fieldsShowed
+    })
+  },
+
+  setSelection: ({
+    containerUuid,
+    recordsSelected
+  }) => {
+    store.commit('setBrowserSelectionsList', {
+      containerUuid,
+      selectionsList: recordsSelected
+    })
+  },
+  getSelection: ({
+    containerUuid
+  }) => {
+    return store.getters.getBrowserSelectionsList({
+      containerUuid
+    })
+  },
+  getRecordCount({ containerUuid }) {
+    return store.getters.getBrowserRecordCount({
+      containerUuid
+    })
+  },
+
+  getPageNumber({ containerUuid }) {
+    return store.getters.getBrowserPageNumber({
+      containerUuid
+    })
+  },
+
+  /**
+   * @returns Promisse with value and displayedValue
+   */
+  getDefaultValue({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName }) {
+    return store.dispatch('getDefaultValueFromServer', {
+      parentUuid,
+      containerUuid,
+      contextColumnNames,
+      browseFieldUuid: uuid,
+      id,
+      //
+      columnName
+    })
+  },
+  getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid, searchValue, isAddBlankValue = false, blankValue }) {
+    return store.dispatch('getLookupListFromServer', {
+      parentUuid,
+      containerUuid,
+      contextColumnNames,
+      browseFieldUuid: uuid,
+      searchValue,
+      // app attributes
+      isAddBlankValue,
+      blankValue
     })
   }
 }

--- a/src/utils/ADempiere/dictionary/panel.js
+++ b/src/utils/ADempiere/dictionary/panel.js
@@ -129,7 +129,8 @@ export function generatePanelAndFields({
   isAddFieldsRange = false,
   isAddFieldUuid = false,
   isAddLinkColumn = false,
-  fieldOverwrite = {}
+  fieldOverwrite = {},
+  sortField = 'sequence' //  sequence, sortNo, seqNoGrid
 }) {
   const fieldAdditionalAttributes = {
     parentUuid,
@@ -189,10 +190,6 @@ export function generatePanelAndFields({
 
   if (!isEmptyValue(fieldsRangeList)) {
     fieldsList = fieldsList.concat(fieldsRangeList)
-    // order range fields
-    fieldsList = sortFields({
-      fieldsList
-    })
   }
 
   // TODO: Improve performance and reduce array cycles
@@ -246,6 +243,11 @@ export function generatePanelAndFields({
       fieldsList.push(fieldUuid)
     }
   }
+
+  fieldsList = sortFields({
+    fieldsList,
+    orderBy: sortField
+  })
 
   // panel for save on store
   const panel = {

--- a/src/utils/ADempiere/dictionary/process.js
+++ b/src/utils/ADempiere/dictionary/process.js
@@ -31,14 +31,14 @@ import { isHiddenField } from '@/utils/ADempiere/references'
  * @param {boolean} isDisplayedFromLogic
  * @returns {boolean}
  */
-export function isDisplayedField({ displayType, isActive, isDisplayed, isDisplayedFromLogic }) {
+export function isDisplayedField({ displayType, isActive, isDisplayed, displayLogic, isDisplayedFromLogic }) {
   // button field not showed
   if (isHiddenField(displayType)) {
     return false
   }
 
   // verify if field is active
-  return isActive && isDisplayed && isDisplayedFromLogic
+  return isActive && isDisplayed && (isEmptyValue(displayLogic) || isDisplayedFromLogic)
 }
 
 /**

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -28,14 +28,14 @@ import { zoomIn } from '@/utils/ADempiere/coreUtils'
 /**
  * Is displayed field in panel single record
  */
-export function isDisplayedField({ isDisplayed, isDisplayedFromLogic, isActive, displayType }) {
+export function isDisplayedField({ isDisplayed, displayLogic, isDisplayedFromLogic, isActive, displayType }) {
   // button field not showed
   if (isHiddenField(displayType)) {
     return false
   }
 
   // verify if field is active and displayed
-  return isActive && isDisplayed && isDisplayedFromLogic
+  return isActive && isDisplayed && (isEmptyValue(displayLogic) || isDisplayedFromLogic)
 }
 
 /**

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -57,7 +57,7 @@ export function generateField({
 
   const componentReference = evalutateTypeField(fieldToGenerate.displayType)
   let evaluatedLogics = {
-    isDisplayedFromLogic: fieldToGenerate.isDisplayed,
+    isDisplayedFromLogic: fieldToGenerate.isDisplayed || fieldToGenerate.isQueryCriteria,
     isMandatoryFromLogic: false,
     isReadOnlyFromLogic: false
   }
@@ -209,7 +209,7 @@ export function generateField({
   if (field.isRange) {
     field.operator = OPERATOR_GREATER_EQUAL.operator
     field.columnNameTo = `${columnName}_To`
-    field.elementNameTo = `${field.elementNameTo}_To`
+    field.elementNameTo = `${field.elementName}_To`
     if (typeRange) {
       field.uuid = `${field.uuid}_To`
       field.columnName = field.columnNameTo
@@ -219,7 +219,11 @@ export function generateField({
       field.defaultValue = field.defaultValueTo
       field.parsedDefaultValue = field.parsedDefaultValueTo
       field.operator = OPERATOR_LESS_EQUAL.operator
-      field.sequence = field.sequence + 1
+
+      // increment order sequence
+      field.sequence = field.sequence > 0 ? field.sequence + 1 : 0
+      field.seqNoGrid = field.seqNoGrid > 0 ? field.seqNoGrid + 1 : 0
+      field.sortNo = field.sortNo > 0 ? field.sortNo + 1 : 0
 
       // if field with value displayed in main panel
       if (!isEmptyValue(parsedDefaultValueTo)) {
@@ -262,8 +266,8 @@ export function getEvaluatedLogics({
     context: getContext
   }
 
-  let isDisplayedFromLogic = isDisplayed
-  if (!isEmptyValue(displayLogic)) {
+  let isDisplayedFromLogic = isEmptyValue(displayLogic)
+  if (isDisplayedFromLogic) {
     isDisplayedFromLogic = evaluator.evaluateLogic({
       ...commonParameters,
       logic: displayLogic

--- a/src/views/ADempiere/Browser/index.vue
+++ b/src/views/ADempiere/Browser/index.vue
@@ -102,9 +102,10 @@ import TitleAndHelp from '@theme/components/ADempiere/TitleAndHelp'
 
 // utils and helper methods
 import {
-  isDisplayedField, isDisplayedColumn,
-  isMandatoryField, isMandatoryColumn,
-  isReadOnlyField, isReadOnlyColumn
+  containerManager,
+  isDisplayedColumn,
+  isMandatoryColumn,
+  isReadOnlyColumn
 } from '@/utils/ADempiere/dictionary/browser.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 
@@ -287,99 +288,6 @@ export default defineComponent({
       store.commit('setBrowserData', {
         containerUuid: browserUuid
       })
-    }
-
-    const containerManager = {
-      getPanel({ containerUuid }) {
-        return store.getters.getStoredBrowser(containerUuid)
-      },
-      getFieldsList({ containerUuid }) {
-        return store.getters.getStoredFieldsFromBrowser(containerUuid)
-      },
-
-      actionPerformed({ field, value, valueTo, containerUuid }) {
-        return store.dispatch('browserActionPerformed', {
-          containerUuid,
-          field,
-          value,
-          valueTo
-        })
-      },
-
-      setDefaultValues: ({ parentUuid, containerUuid }) => {
-        store.dispatch('setBrowserDefaultValues', {
-          parentUuid,
-          containerUuid
-        })
-      },
-
-      /**
-       * Is displayed field in panel single record
-       */
-      isDisplayedField,
-
-      isMandatoryField,
-
-      isReadOnlyField,
-
-      changeFieldShowedFromUser({ containerUuid, fieldsShowed }) {
-        store.dispatch('changeBrowserFieldShowedFromUser', {
-          containerUuid,
-          fieldsShowed
-        })
-      },
-
-      setSelection: ({
-        containerUuid,
-        recordsSelected
-      }) => {
-        store.commit('setBrowserSelectionsList', {
-          containerUuid,
-          selectionsList: recordsSelected
-        })
-      },
-      getSelection: ({
-        containerUuid
-      }) => {
-        return store.getters.getBrowserSelectionsList({
-          containerUuid
-        })
-      },
-      getRecordCount({ containerUuid }) {
-        return store.getters.getBrowserRecordCount({
-          containerUuid
-        })
-      },
-
-      getPageNumber({ containerUuid }) {
-        return store.getters.getBrowserPageNumber({
-          containerUuid
-        })
-      },
-
-      /**
-       * @returns Promisse with value and displayedValue
-       */
-      getDefaultValue({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName }) {
-        return store.dispatch('getDefaultValueFromServer', {
-          parentUuid,
-          containerUuid,
-          contextColumnNames,
-          browseFieldUuid: uuid,
-          id,
-          //
-          columnName
-        })
-      },
-      getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid, searchValue }) {
-        return store.dispatch('getLookupListFromServer', {
-          parentUuid,
-          containerUuid,
-          contextColumnNames,
-          browseFieldUuid: uuid,
-          searchValue
-        })
-      }
     }
 
     const containerManagerTable = {

--- a/src/views/ADempiere/Process/mixinProcess.js
+++ b/src/views/ADempiere/Process/mixinProcess.js
@@ -79,13 +79,16 @@ export default (processUuid) => {
         columnName
       })
     },
-    getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid, searchValue }) {
+    getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid, searchValue, isAddBlankValue = false, blankValue }) {
       return store.dispatch('getLookupListFromServer', {
         parentUuid,
         containerUuid,
         contextColumnNames,
         processParameterUuid: uuid,
-        searchValue
+        searchValue,
+        // app attributes
+        isAddBlankValue,
+        blankValue
       })
     }
   }

--- a/src/views/ADempiere/Report/mixinReport.js
+++ b/src/views/ADempiere/Report/mixinReport.js
@@ -79,13 +79,16 @@ export default (reportUuid) => {
         columnName
       })
     },
-    getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid, searchValue }) {
+    getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid, searchValue, isAddBlankValue = false, blankValue }) {
       return store.dispatch('getLookupListFromServer', {
         parentUuid,
         containerUuid,
         contextColumnNames,
         processParameterUuid: uuid,
-        searchValue
+        searchValue,
+        // app attributes
+        isAddBlankValue,
+        blankValue
       })
     }
   }

--- a/src/views/ADempiere/Window/index.vue
+++ b/src/views/ADempiere/Window/index.vue
@@ -352,7 +352,7 @@ export default defineComponent({
           columnName
         })
       },
-      getLookupList({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName, searchValue }) {
+      getLookupList({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName, searchValue, isAddBlankValue, blankValue }) {
         return store.dispatch('getLookupListFromServer', {
           parentUuid,
           containerUuid,
@@ -360,7 +360,10 @@ export default defineComponent({
           fieldUuid: uuid,
           id,
           columnName,
-          searchValue
+          searchValue,
+          // app attributes
+          isAddBlankValue,
+          blankValue
         })
       },
 


### PR DESCRIPTION
Abrir la consulta inteligente `Generar Plan de Recolección basado en ventas`.

* Listar los valores del campo `País`.
* Seleccionar un valor.
* Listar los valores del campo `Región`, y verificar que los resultados pertenezcan a la región seleccionada.




https://user-images.githubusercontent.com/20288327/171282972-c37aa3bb-1ba0-466a-8239-67ab1b7c33b0.mp4

https://user-images.githubusercontent.com/20288327/171284272-1b22e4f1-26fc-44c7-9080-3a0beac40da7.mp4



En las consultas inteligentes del Zk o del Swing no parecen funcionar bien las validaciones dinámicas.


https://user-images.githubusercontent.com/20288327/171284331-78de75c0-611d-48e3-8333-dfc541201a06.mp4
