### PR TITLE
feat: Add value to overwrite default value.

### DIFF
--- a/src/api/ADempiere/user-interface/persistence.js
+++ b/src/api/ADempiere/user-interface/persistence.js
@@ -109,6 +109,7 @@ export function getEntities({
  * @param {string} browseFieldUuid, uuid of browser field
  * @param {integer} id, identifier of field
  * @param {string} columnUuid, uuid of column
+ * @param {mixed} value, value to overwrite default value on dictionary definition
  */
 export function requestDefaultValue({
   contextAttributesList,
@@ -116,7 +117,8 @@ export function requestDefaultValue({
   processParameterUuid,
   browseFieldUuid,
   id,
-  columnUuid
+  columnUuid,
+  value
 }) {
   let contextAttributes = []
   if (!isEmptyValue(contextAttributesList)) {
@@ -137,7 +139,8 @@ export function requestDefaultValue({
       process_parameter_uuid: processParameterUuid,
       browse_field_uuid: browseFieldUuid,
       id,
-      column_uuid: columnUuid
+      column_uuid: columnUuid,
+      value
     }
   })
     .then(valueResponse => {

--- a/src/store/modules/ADempiere/defaultValueManager.js
+++ b/src/store/modules/ADempiere/defaultValueManager.js
@@ -61,6 +61,7 @@ const defaultValueManager = {
      * @param {string} columnName
      * @param {array} contextColumnNames
      * @param {string} fieldUuid|processParameterUuid|columnUuid|browseFieldUuid
+     * @param {mixed} value overwrite default value on dictionary definition
      */
     getDefaultValueFromServer({ state, commit, rootGetters }, {
       parentUuid,
@@ -72,7 +73,8 @@ const defaultValueManager = {
       processParameterUuid,
       browseFieldUuid,
       columnUuid,
-      columnName
+      columnName,
+      value
     }) {
       const defaultEmptyResponse = {
         uuid: undefined,
@@ -104,7 +106,7 @@ const defaultValueManager = {
           return
         }
 
-        const clientId = rootGetters.getPreferenceClientId
+        const clientId = rootGetters.getSessionContextClientId
 
         let key = clientId
         if (!isEmptyValue(fieldUuid)) {
@@ -124,13 +126,15 @@ const defaultValueManager = {
           return
         }
         state.inRequest.set(key, true)
+
         requestDefaultValue({
           contextAttributesList,
           id,
           fieldUuid,
           processParameterUuid,
           browseFieldUuid,
-          columnUuid
+          columnUuid,
+          value
         })
           .then(valueResponse => {
             const values = {}
@@ -145,7 +149,7 @@ const defaultValueManager = {
                 values[column] = value
               })
             }
-            const value = values.KeyColumn
+            const valueOfServer = values.KeyColumn
             const displayedValue = values.DisplayColumn
 
             commit('setDefaultValue', {
@@ -162,7 +166,7 @@ const defaultValueManager = {
               parentUuid,
               containerUuid,
               columnName,
-              value
+              value: valueOfServer
             })
             if (!isEmptyValue(values.DisplayColumn)) {
               commit('updateValueOfField', {
@@ -175,7 +179,7 @@ const defaultValueManager = {
 
             resolve({
               displayedValue,
-              value: value,
+              value: valueOfServer,
               uuid: values.uuid
             })
           })
@@ -197,7 +201,7 @@ const defaultValueManager = {
       value
     }) {
       return new Promise(resolve => {
-        const clientId = rootGetters.getPreferenceClientId
+        const clientId = rootGetters.getSessionContextClientId
         let key = `${clientId}|${uuid}`
 
         const contextAttributesList = getContextAttributes({
@@ -238,7 +242,7 @@ const defaultValueManager = {
         })
       }
 
-      const clientId = rootGetters.getPreferenceClientId
+      const clientId = rootGetters.getSessionContextClientId
       let key = `${clientId}|${uuid}`
       const contextKey = generateContextKey(contextAttributesList)
       key += contextKey

--- a/src/store/modules/ADempiere/lookupManager.js
+++ b/src/store/modules/ADempiere/lookupManager.js
@@ -144,7 +144,7 @@ const lookupManager = {
               })
             }
 
-            const clientId = rootGetters.getPreferenceClientId
+            const clientId = rootGetters.getSessionContextClientId
 
             let key = clientId
             if (!isEmptyValue(fieldUuid)) {
@@ -192,7 +192,7 @@ const lookupManager = {
           value
         })
 
-        const clientId = rootGetters.getPreferenceClientId
+        const clientId = rootGetters.getSessionContextClientId
 
         const contextAttributesList = getContextAttributes({
           parentUuid,
@@ -227,7 +227,7 @@ const lookupManager = {
       contextAttributesList = [],
       uuid
     }) => {
-      let key = rootGetters.getPreferenceClientId
+      let key = rootGetters.getSessionContextClientId
       if (!isEmptyValue(uuid)) {
         key += `|${uuid}`
       }

--- a/src/store/modules/ADempiere/panel/getters.js
+++ b/src/store/modules/ADempiere/panel/getters.js
@@ -283,6 +283,7 @@ const getters = {
     if (isEmptyValue(fieldsList)) {
       fieldsList = getters.getFieldsListFromPanel(containerUuid)
     }
+
     const attributesRangue = []
     const attributesDisplayColumn = []
     const attributesObject = {}
@@ -291,26 +292,32 @@ const getters = {
         const { id, uuid, columnName, defaultValue, contextColumnNames } = fieldItem
         const isSQL = String(defaultValue).includes('@SQL=') && isGetServer
 
-        const parsedDefaultValue = getDefaultValue({
-          ...fieldItem,
-          parentUuid,
-          contextColumnNames,
-          isSOTrxMenu
-        })
+        let parsedDefaultValue
+        if (!isSQL) {
+          parsedDefaultValue = getDefaultValue({
+            ...fieldItem,
+            parentUuid,
+            contextColumnNames,
+            isSOTrxMenu
+          })
+        }
         attributesObject[columnName] = parsedDefaultValue
 
         if (fieldItem.isRange && fieldItem.componentPath !== 'FieldNumber') {
           const { columnNameTo, elementNameTo, defaultValueTo } = fieldItem
           const isSQLTo = String(defaultValueTo).includes('@SQL=') && isGetServer
 
-          const parsedDefaultValueTo = getDefaultValue({
-            ...fieldItem,
-            parentUuid,
-            contextColumnNames,
-            isSOTrxMenu,
-            columnName: columnNameTo,
-            elementName: elementNameTo
-          })
+          let parsedDefaultValueTo
+          if (!isSQLTo) {
+            parsedDefaultValueTo = getDefaultValue({
+              ...fieldItem,
+              parentUuid,
+              contextColumnNames,
+              isSOTrxMenu,
+              columnName: columnNameTo,
+              elementName: elementNameTo
+            })
+          }
 
           attributesObject[columnNameTo] = parsedDefaultValueTo
           attributesRangue.push({

--- a/src/store/modules/ADempiere/sessionContext.js
+++ b/src/store/modules/ADempiere/sessionContext.js
@@ -15,11 +15,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import Vue from 'vue'
-// Delete when get global context and account context
-import { isEmptyValue, typeValue } from '@/utils/ADempiere/valueUtils.js'
-import { CLIENT, ORGANIZATION } from '@/utils/ADempiere/constants/systemColumns.js'
 
-const preference = {
+// constants
+import { CLIENT, ORGANIZATION } from '@/utils/ADempiere/constants/systemColumns.js'
+import { ACCOUNTING_CONTEXT_PREFIX, GLOBAL_CONTEXT_PREFIX } from '@/utils/ADempiere/contextUtils'
+
+// utils and helper methods
+import { isEmptyValue, typeValue } from '@/utils/ADempiere/valueUtils.js'
+
+const sessionContext = {
   state: {
     preference: {}
   },
@@ -154,12 +158,33 @@ const preference = {
     }
   },
   getters: {
+    getAllSessionContext: (state) => {
+      return state.preference
+    },
+    getGlobalContext: (state) => {
+      const globalContext = {}
+      Object.keys(state.preference).forEach(key => {
+        if (key.startsWith(GLOBAL_CONTEXT_PREFIX)) {
+          globalContext[key] = state.preference[key]
+        }
+      })
+      return globalContext
+    },
+    getAccountingContext: (state) => {
+      const accountingContext = {}
+      Object.keys(state.preference).forEach(key => {
+        if (key.startsWith(ACCOUNTING_CONTEXT_PREFIX)) {
+          accountingContext[key] = state.preference[key]
+        }
+      })
+      return accountingContext
+    },
     /**
      * @param  {string} parentUuid
      * @param  {string} containerUuid
      * @param  {string} columnName
      */
-    getPreference: (state) => ({
+    getSessionContext: (state) => ({
       parentUuid,
       containerUuid,
       columnName
@@ -190,16 +215,13 @@ const preference = {
       value = state.preference[columnName]
       return value
     },
-    getAllPreference: (state) => {
-      return state.preference
+    getSessionContextClientId: (state) => {
+      return parseInt(state.preference[GLOBAL_CONTEXT_PREFIX + CLIENT], 10)
     },
-    getPreferenceClientId: (state) => {
-      return parseInt(state.preference['#' + CLIENT], 10)
-    },
-    getPreferenceOrgId: (state) => {
-      return parseInt(state.preference['#' + ORGANIZATION], 10)
+    getSessionContextOrgtId: (state) => {
+      return parseInt(state.preference[GLOBAL_CONTEXT_PREFIX + ORGANIZATION], 10)
     }
   }
 }
 
-export default preference
+export default sessionContext

--- a/src/utils/ADempiere/dictionary/browser.js
+++ b/src/utils/ADempiere/dictionary/browser.js
@@ -279,7 +279,7 @@ export const containerManager = {
   /**
    * @returns Promisse with value and displayedValue
    */
-  getDefaultValue({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName }) {
+  getDefaultValue({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName, value }) {
     return store.dispatch('getDefaultValueFromServer', {
       parentUuid,
       containerUuid,
@@ -287,7 +287,8 @@ export const containerManager = {
       browseFieldUuid: uuid,
       id,
       //
-      columnName
+      columnName,
+      value
     })
   },
   getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid, searchValue, isAddBlankValue = false, blankValue }) {

--- a/src/utils/ADempiere/evaluator.js
+++ b/src/utils/ADempiere/evaluator.js
@@ -16,6 +16,7 @@
 
 import { convertStringToBoolean } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
+import { GLOBAL_CONTEXT_PREFIX, ACCOUNTING_CONTEXT_PREFIX } from '@/utils/ADempiere/contextUtils'
 
 /**
  * This class is used for evaluate a conditional
@@ -151,8 +152,8 @@ class evaluator {
     expr = /@/
     if (expr.test(first)) {
       first = first.replace(/@/g, '').trim()
-      isGlobal = first.startsWith('#')
-      isCountable = first.startsWith('$')
+      isGlobal = first.startsWith(GLOBAL_CONTEXT_PREFIX)
+      isCountable = first.startsWith(ACCOUNTING_CONTEXT_PREFIX)
       if (isGlobal || isCountable) {
         parentUuid = null
         containerUuid = null

--- a/src/views/ADempiere/Process/mixinProcess.js
+++ b/src/views/ADempiere/Process/mixinProcess.js
@@ -68,7 +68,7 @@ export default (processUuid) => {
     /**
      * @returns Promisse with value and displayedValue
      */
-    getDefaultValue({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName }) {
+    getDefaultValue({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName, value }) {
       return store.dispatch('getDefaultValueFromServer', {
         parentUuid,
         containerUuid,
@@ -76,7 +76,8 @@ export default (processUuid) => {
         processParameterUuid: uuid,
         id,
         //
-        columnName
+        columnName,
+        value
       })
     },
     getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid, searchValue, isAddBlankValue = false, blankValue }) {

--- a/src/views/ADempiere/Report/mixinReport.js
+++ b/src/views/ADempiere/Report/mixinReport.js
@@ -68,7 +68,7 @@ export default (reportUuid) => {
     /**
      * @returns Promisse with value and displayedValue
      */
-    getDefaultValue({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName }) {
+    getDefaultValue({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName, value }) {
       return store.dispatch('getDefaultValueFromServer', {
         parentUuid,
         containerUuid,
@@ -76,7 +76,8 @@ export default (reportUuid) => {
         processParameterUuid: uuid,
         id,
         //
-        columnName
+        columnName,
+        value
       })
     },
     getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid, searchValue, isAddBlankValue = false, blankValue }) {

--- a/src/views/ADempiere/Window/index.vue
+++ b/src/views/ADempiere/Window/index.vue
@@ -161,7 +161,7 @@ export default defineComponent({
             columnName: CLIENT
           })
           // evaluate client id context with record
-          const preferenceClientId = store.getters.getPreferenceClientId
+          const preferenceClientId = store.getters.getSessionContextClientId
           if (clientIdRecord !== preferenceClientId) {
             return true
           }
@@ -233,7 +233,7 @@ export default defineComponent({
         }
 
         // evaluate client id context with record
-        const preferenceClientId = store.getters.getPreferenceClientId
+        const preferenceClientId = store.getters.getSessionContextClientId
         if (preferenceClientId !== parseInt(row.AD_Client_ID, 10) && isWithRecord) {
           return true
         }
@@ -341,7 +341,7 @@ export default defineComponent({
       /**
        * @returns Promisse with value and displayedValue
        */
-      getDefaultValue({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName }) {
+      getDefaultValue({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName, value }) {
         return store.dispatch('getDefaultValueFromServer', {
           parentUuid,
           containerUuid,
@@ -349,7 +349,8 @@ export default defineComponent({
           fieldUuid: uuid,
           id,
           //
-          columnName
+          columnName,
+          value
         })
       },
       getLookupList({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName, searchValue, isAddBlankValue, blankValue }) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature


#### Steps to reproduce

1. Expand `Open Item` menu.
2. Open `Generate Payment Selection (From Invoice)`

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/171664982-fc60601b-e071-49bc-afac-e27ea06972d6.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/171664987-528f88f5-7548-406a-ac84-7616ff511702.mp4

#### Expected behavior
In the backend it was looking for the default value of the `Bank Account` field, but since it was not in the dictionary definition it returned empty values.

In the context of the session we have the value in the `Bank Account` field, so it should be automatically set, overwriting the possible default value in case of having it.

Also, when changing the value of this field, all the fields that are dependent on it, such as the `Currency` and `Current Balance` fields, must change or clear their values.


#### Other relevant information
- Your OS: Linux Mint 20.3 x64.
- Web Browser: Mozilla Firefox 99.0
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes #11 #67 #98 #140
