### PR TITLE
feat: Hidden mandatory field without default value

### DIFF
--- a/src/store/modules/ADempiere/panel/getters.js
+++ b/src/store/modules/ADempiere/panel/getters.js
@@ -159,12 +159,17 @@ const getters = {
     // all optionals (not mandatory) fields
     return fieldsList
       .filter(fieldItem => {
+        const { defaultValue } = fieldItem
         const isMandatory = fieldItem.isMandatory || fieldItem.isMandatoryFromLogic
-        if (isMandatory && !isTable) {
+
+        // parent column
+        if (fieldItem.isParent) {
+          return true
+        }
+        if (isMandatory && isEmptyValue(defaultValue) && !isTable) {
           return false
         }
 
-        const { defaultValue } = fieldItem
         if (isEvaluateDefaultValue && isEvaluateShowed) {
           return showedMethod(fieldItem) &&
             !isEmptyValue(defaultValue)


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature


Mandatory fields can now be hidden, as long as they do not have a default value or are a parent column.

#### Steps to reproduce
1. Open any window.
2. Showed field options in mandatory field.
3. Select hidden this field.

#### Screenshot or Gif


https://user-images.githubusercontent.com/20288327/173834444-58568998-176c-42f9-9f93-1d67e764f9e4.mp4

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 100.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.



