### PR TITLE
feat: Hidden mandatory field without default value

### DIFF
--- a/src/store/modules/ADempiere/panel/getters.js
+++ b/src/store/modules/ADempiere/panel/getters.js
@@ -159,12 +159,17 @@ const getters = {
     // all optionals (not mandatory) fields
     return fieldsList
       .filter(fieldItem => {
+        const { defaultValue } = fieldItem
         const isMandatory = fieldItem.isMandatory || fieldItem.isMandatoryFromLogic
-        if (isMandatory && !isTable) {
+
+        // parent column
+        if (fieldItem.isParent) {
+          return true
+        }
+        if (isMandatory && isEmptyValue(defaultValue) && !isTable) {
           return false
         }
 
-        const { defaultValue } = fieldItem
         if (isEvaluateDefaultValue && isEvaluateShowed) {
           return showedMethod(fieldItem) &&
             !isEmptyValue(defaultValue)


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `GardenAdmin`.
2. Open `View` window.
3. In `View Definition` tab select aciton menu `Create New`

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/173836388-c6abb7e2-1fe1-4b9d-bacc-c7be530f0866.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/173836395-b5f8b533-d529-4848-940b-4b311bc379ed.mp4



#### Expected behavior
If record parent is other cliend expected showed correct displayed value in `Client` field.

`View` field is parent column and without default value, set parent record value.


#### Other relevant information

- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 100.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

