### PR TITLE
fix: Set default values on tab childs.

### DIFF
--- a/src/store/modules/ADempiere/defaultValueManager.js
+++ b/src/store/modules/ADempiere/defaultValueManager.js
@@ -20,6 +20,9 @@ import Vue from 'vue'
 import { requestDefaultValue } from '@/api/ADempiere/user-interface/persistence.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 
+// constants
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
+
 // utils and helper methods
 import { isSameSize } from '@/utils/ADempiere/formatValue/iterableFormat'
 import { generateContextKey, getContextAttributes } from '@/utils/ADempiere/contextUtils'
@@ -101,7 +104,7 @@ const defaultValueManager = {
 
         const isWithoutValues = contextAttributesList.find(attribute => isEmptyValue(attribute.value))
         if (isWithoutValues) {
-          console.warn(`Without response, fill the ${isWithoutValues.columnName} field.`)
+          console.warn(`Default value without response, fill the ${isWithoutValues.columnName} field.`)
           resolve(defaultEmptyResponse)
           return
         }
@@ -172,7 +175,7 @@ const defaultValueManager = {
               commit('updateValueOfField', {
                 parentUuid,
                 containerUuid,
-                columnName: `DisplayColumn_${columnName}`,
+                columnName: DISPLAY_COLUMN_PREFIX + columnName,
                 value: displayedValue
               })
             }

--- a/src/store/modules/ADempiere/panel/actions.js
+++ b/src/store/modules/ADempiere/panel/actions.js
@@ -415,9 +415,8 @@ const actions = {
    * @param {array} fieldsList, list of fields
    * @param {object} containerManager, logic implement by panel type
    * TODO: Not working with fields generated on lookupFactory
-   * TODO: Evaluated with reference (direct query) lookup item
    */
-  changeDependentFieldsList({ commit, dispatch, getters }, {
+  changeDependentFieldsList({ commit, getters, rootGetters }, {
     field,
     fieldsList,
     containerManager
@@ -497,14 +496,33 @@ const actions = {
           value: fieldDependent.defaultValue
         }).query
 
-        const { displayedValue, value: newValue } = containerManager.getDefaultValue({
-          parentUuid,
+        let newValue, displayedValue
+
+        newValue = rootGetters.getValueOfField({
           containerUuid,
-          contextColumnNames: fieldDependent.contextColumnNames,
-          uuid: fieldDependent.uuid,
-          id: fieldDependent.id,
           columnName: fieldDependent.columnName
         })
+        if (!isEmptyValue(newValue)) {
+          displayedValue = rootGetters.getValueOfField({
+            containerUuid,
+            columnName: fieldDependent.displayColumnName
+          })
+        } else {
+          const {
+            value: valueByServer,
+            displayedValue: displayedValueByServer
+          } = containerManager.getDefaultValue({
+            parentUuid,
+            containerUuid,
+            contextColumnNames: fieldDependent.contextColumnNames,
+            uuid: fieldDependent.uuid,
+            id: fieldDependent.id,
+            columnName: fieldDependent.columnName
+          })
+
+          displayedValue = displayedValueByServer
+          newValue = valueByServer
+        }
 
         // update values for field
         commit('updateValueOfField', {

--- a/src/store/modules/ADempiere/panel/getters.js
+++ b/src/store/modules/ADempiere/panel/getters.js
@@ -342,7 +342,7 @@ const getters = {
               uuid
             })
             if (!isEmptyValue(optionsList)) {
-              const option = optionsList.find(item => item.id === parsedDefaultValue)
+              const option = optionsList.find(item => item.value === parsedDefaultValue)
               if (!isEmptyValue(option)) {
                 displayedValue = option.displayedValue
               }

--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -126,7 +126,7 @@ const windowManager = {
               value
             })
           } else {
-            console.warn(`without context to ${linkColumnName} to filter in getEntities`)
+            console.warn(`Get entities without context to ${linkColumnName} to filter in getEntities`)
           }
         }
         if (!isEmptyValue(parentColumnName) &&
@@ -143,7 +143,7 @@ const windowManager = {
               value
             })
           } else {
-            console.warn(`without context to ${parentColumnName} to filter in getEntities`)
+            console.warn(`Get entities without context to ${parentColumnName} to filter in getEntities`)
           }
         }
 
@@ -156,11 +156,7 @@ const windowManager = {
 
         const isWithoutValues = contextAttributesList.find(attribute => isEmptyValue(attribute.value))
         if (isWithoutValues) {
-          console.warn(`Without response, fill the **${isWithoutValues.key}** field in **${name}** tab.`)
-          showMessage({
-            message: language.t('notifications.mandatoryFieldMissing') + isWithoutValues.key,
-            type: 'info'
-          })
+          console.warn(`Get entites without response, fill the **${isWithoutValues.key}** field in **${name}** tab.`)
           resolve([])
           return
         }

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -30,6 +30,11 @@ import {
 } from '@/utils/ADempiere/constants/systemColumns'
 
 /**
+ * Display Column Prefix on Column Name: "DisplayColumn_ColumnName"
+ */
+export const DISPLAY_COLUMN_PREFIX = `DisplayColumn_`
+
+/**
  * Generate field to app
  * @param {object}  fieldToGenerate
  * @param {object}  moreAttributes, additional attributes
@@ -172,7 +177,7 @@ export function generateField({
     componentPath: componentReference.componentPath,
     isSupported: componentReference.isSupported,
     size: componentReference.size || DEFAULT_SIZE,
-    displayColumnName: `DisplayColumn_${columnName}`, // key to display column
+    displayColumnName: DISPLAY_COLUMN_PREFIX + columnName, // key to display column
     // value attributes
     parsedDefaultValue,
     parsedDefaultValueTo,

--- a/src/utils/ADempiere/formatValue/booleanFormat.js
+++ b/src/utils/ADempiere/formatValue/booleanFormat.js
@@ -22,7 +22,7 @@ import language from '@/lang'
  * @returns {string} true => 'Yes' or 'Si', false => 'Not' or 'No'
  */
 export const convertBooleanToTranslationLang = (booleanValue) => {
-  if (booleanValue === true || booleanValue === 'true' || booleanValue === 'Y') {
+  if (booleanValue === true || booleanValue === 'true' || booleanValue === 'Y' || booleanValue === 'Yes') {
     return language.t('components.switchActiveText')
   }
 
@@ -36,7 +36,7 @@ export const convertBooleanToTranslationLang = (booleanValue) => {
  * @returns {strin}
  */
 export const convertBooleanToString = (booleanValue, isForce = true) => {
-  if (booleanValue === true || booleanValue === 'true' || booleanValue === 'Y') {
+  if (booleanValue === true || booleanValue === 'true' || booleanValue === 'Y' || booleanValue === 'Yes') {
     return 'Y'
   }
   if (isForce) {
@@ -55,12 +55,14 @@ export const convertStringToBoolean = (valueToParsed) => {
 
   switch (String(valueToParsed).trim()) {
     case 'N':
+    case 'No':
     case 'false':
     case language.t('components.switchInactiveText'):
       valReturn = false
       break
 
     case 'Y':
+    case 'Yes':
     case 'true':
     case language.t('components.switchActiveText'):
       valReturn = true

--- a/src/utils/ADempiere/formatValue/numberFormat.js
+++ b/src/utils/ADempiere/formatValue/numberFormat.js
@@ -66,6 +66,13 @@ export function formatNumber({
 
   let formattedNumber
   switch (displayType) {
+    // ID, Integer
+    case (isIntegerField(displayType) && displayType):
+    default:
+      formattedNumber = formatQuantity({ value, isInteger: true })
+      break
+
+    // Amount, Costs+Prices
     case (isCurrencyField(displayType) && displayType):
       formattedNumber = formatPrice({ value, currency, country })
       break
@@ -73,11 +80,6 @@ export function formatNumber({
     case NUMBER.id:
     case QUANTITY.id:
       formattedNumber = formatQuantity({ value })
-      break
-
-    case (isIntegerField(displayType) && displayType):
-    default:
-      formattedNumber = formatQuantity({ value, isInteger: true })
       break
   }
 

--- a/src/utils/ADempiere/valueFormat.js
+++ b/src/utils/ADempiere/valueFormat.js
@@ -36,6 +36,9 @@ export function convertObjectToKeyValue({
   keyName = 'columnName',
   valueName = 'value'
 }) {
+  if (isEmptyValue(object)) {
+    return []
+  }
   return Object.keys(object).map(key => {
     const returnPairs = {}
     returnPairs[keyName] = key


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `GardenAdmin`.
2. Open `View` window.
3. In `View Definition` tab select aciton menu `Create New`

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/173836388-c6abb7e2-1fe1-4b9d-bacc-c7be530f0866.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/173836395-b5f8b533-d529-4848-940b-4b311bc379ed.mp4



#### Expected behavior
If record parent is other cliend expected showed correct displayed value in `Client` field.

`View` field is parent column and without default value, set parent record value.


#### Other relevant information

- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 100.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

