### PR TITLE
fix: Set parent value.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -18,6 +18,7 @@
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 import { isDisplayedField, isMandatoryField } from '@/utils/ADempiere/dictionary/window.js'
 import { DISPLAY_COLUMN_PREFIX, getDefaultValue } from '@/utils/ADempiere/dictionaryUtils.js'
+import { getContext } from '@/utils/ADempiere/contextUtils'
 
 /**
  * Dictionary Window Getters
@@ -185,7 +186,7 @@ export default {
         const { uuid, columnName, defaultValue, contextColumnNames } = fieldItem
         const isSQL = String(defaultValue).includes('@SQL=') && isGetServer
         const isLinkColumn = !isEmptyValue(linkColumnName) && columnName === linkColumnName
-        const isParentColumn = !isEmptyValue(parentColumnName) && columnName === parentColumnName
+        const isParentColumn = fieldItem.isParent || (!isEmptyValue(parentColumnName) && columnName === parentColumnName)
 
         let parsedDefaultValue
         if (!isSQL) {
@@ -198,16 +199,17 @@ export default {
         }
         // get value of link column
         if (isLinkColumn) {
-          parsedDefaultValue = rootGetters.getValueOfField({
+          parsedDefaultValue = getContext({
             parentUuid,
-            columnName: linkColumnName
+            columnName
           })
         }
         // get value of parent column
         if (isParentColumn) {
-          parsedDefaultValue = rootGetters.getValueOfField({
+          parsedDefaultValue = getContext({
             parentUuid,
-            columnName: parentColumnName
+            columnName,
+            isForceSession: true
           })
         }
         attributesObject[columnName] = parsedDefaultValue
@@ -219,7 +221,7 @@ export default {
           if (!isEmptyValue(parsedDefaultValue)) {
             // get displayed value of link column
             if (isLinkColumn) {
-              displayedValue = rootGetters.getValueOfField({
+              displayedValue = getContext({
                 parentUuid,
                 columnName: DISPLAY_COLUMN_PREFIX + linkColumnName
               })
@@ -227,9 +229,9 @@ export default {
 
             // get displayed value of parent column
             if (isParentColumn) {
-              displayedValue = rootGetters.getValueOfField({
+              displayedValue = getContext({
                 parentUuid,
-                columnName: DISPLAY_COLUMN_PREFIX + parentColumnName
+                columnName: DISPLAY_COLUMN_PREFIX + columnName
               })
             }
 

--- a/src/store/modules/ADempiere/field.js
+++ b/src/store/modules/ADempiere/field.js
@@ -19,6 +19,7 @@ import Vue from 'vue'
 import { requestFieldMetadata } from '@/api/ADempiere/dictionary/window'
 // constants
 import { DEFAULT_SIZE_COLUMN } from '@/utils/ADempiere/componentUtils'
+import { isEmptyValue } from '@/utils/ADempiere'
 
 const initStateLookup = {
   referenceList: [],
@@ -145,7 +146,10 @@ const field = {
       })
     },
     getSizeColumn: (state, getters) => ({ containerUuid }) => {
-      return state.defaultSizeField[containerUuid].sizeField || DEFAULT_SIZE_COLUMN
+      if (!isEmptyValue(state.defaultSizeField[containerUuid])) {
+        return state.defaultSizeField[containerUuid].sizeField || DEFAULT_SIZE_COLUMN
+      }
+      return DEFAULT_SIZE_COLUMN
     }
   }
 }

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -45,7 +45,9 @@ export const PREFERENCE_CONTEXT_PREFIX = evaluator.PREFERENCE_CONTEXT_PREFIX
  * Get context state from vuex store
  * @param {string} parentUuid UUID Window
  * @param {string} containerUuid  UUID Tab, Process, SmartBrowser, Report and Form
- * @param {boolean} isBooleanToString if convert true to 'Y'
+ * @param {boolean} isBooleanToString if convert true to 'Y', or return string
+ * @param {boolean} isForceBoolean if convert boolean to string force 'Example' to true
+ * @param {boolean} isForceSession find into global (#) and accounting ($) context
  * @param {string} columnName (context)  Entity to search
  * @returns
  */
@@ -54,6 +56,7 @@ export const getContext = ({
   containerUuid,
   isBooleanToString = false,
   isForceBoolean = true,
+  isForceSession = false,
   columnName
 }) => {
   let value
@@ -75,6 +78,22 @@ export const getContext = ({
       containerUuid,
       columnName
     })
+
+    // get to global and accounting context
+    if (isForceSession && isEmptyValue(value)) {
+      value = store.getters.getSessionContext({
+        parentUuid,
+        containerUuid,
+        columnName: GLOBAL_CONTEXT_PREFIX + columnName
+      })
+      if (isEmptyValue(value)) {
+        value = store.getters.getSessionContext({
+          parentUuid,
+          containerUuid,
+          columnName: ACCOUNTING_CONTEXT_PREFIX + columnName
+        })
+      }
+    }
   }
 
   if (isBooleanToString) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Business Partner` window and set record.
2. See `Business Partner` field in `Customer Accounting` tab.
3. Change to `Location` tab.
4. See `Business Parter` field.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/174102970-a03e2cb2-29b4-4cfc-8528-9c196be0f672.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/174102965-7d33ef1a-bd46-477c-b1ce-5a4da0362489.mp4


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/140
