### PR TITLE
fix: Release docs generated error.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,6 +50,12 @@ jobs:
           yarn ci
           yarn build
 
+      - name: Upload dist docs
+        uses: actions/upload-artifact@v3
+        with:
+          name: adempiere-vue-docs
+          path: docs/.vuepress/dist
+
       - name: Init new repo in dist folder and commit generated files
         run: |
           cd docs/.vuepress/dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -150,7 +150,7 @@ jobs:
         run: |
           cd docs
           yarn ci
-          yarn build --if-present
+          yarn build
 
       - name: Upload dist docs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Create new release.
2. See actions related on release.

#### Screenshot or Gif

![github-docs](https://user-images.githubusercontent.com/20288327/174114933-939e452d-192d-47a3-b78d-d7d27c9f8d07.png)


#### Additional context

https://github.com/EdwinBetanc0urt/adempiere-vue/actions/runs/2510203565

the step of uploading the image to docker hub generated an error because I have not configured the credentials. You must create a condition if you have not configured the secrets, do not run the step of publishing to docker hub.

