### PR TITLE
feat: Change API_URL to localhost with port 8085.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
-# This file was contributed by Carlos Parada and Yamel Senih from ERP Consultores y Asociados, C.A
+# This file was contributed by Carlos Parada, Edwin Betancourt, and Yamel Senih from ERP Consultores y Asociados, C.A
 
 name: Publish Project
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,15 +92,45 @@ jobs:
     steps:
       - id: check_secret_job
         run: |
-          if [[ "${{ secrets.DOCKER_REPO_FRONTEND }}" != "" && \
-                "${{ secrets.DOCKER_USERNAME }}" != "" && \
-                "${{ secrets.DOCKER_TOKEN }}" != "" ]]; \
+          if [[ "${{ secrets.DOCKER_USERNAME }}" != "" ]]; \
           then
             echo "Secrets to use a container registry were configured in the repo"
             echo "::set-output name=is_have_secrets::true"
           else
             echo "Secrets to use a container registry were not configured in the repo"
             echo "::set-output name=is_have_secrets::false"
+          fi
+
+  # Check secrets to push image in docker hub registry
+  check-docker-secrets-token:
+    name: Check if docker hub registry information was set on secrets
+    needs:
+      - build-app
+    runs-on: ubuntu-latest
+    steps:
+      - id: check_secret_job
+        run: |
+          if [[ "${{ secrets.DOCKER_TOKEN }}" != null ]]; \
+          then
+            echo "Secrets to use a container registry were configured in the repo"
+          else
+            echo "Secrets to use a container registry were not configured in the repo"
+          fi
+
+  # Check secrets to push image in docker hub registry
+  check-docker-secrets-repo:
+    name: Check if docker hub registry information was set on secrets
+    needs:
+      - build-app
+    runs-on: ubuntu-latest
+    steps:
+      - id: check_secret_job
+        run: |
+          if [[ "${{ secrets.DOCKER_REPO_FRONTEND }}" != "" ]]; \
+          then
+            echo "Secrets to use a container registry were configured in the repo"
+          else
+            echo "Secrets to use a container registry were not configured in the repo"
           fi
 
   # Publish docker image in Docker Hub registry to application

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,8 @@ jobs:
   # Publish dist binaries to application
   publish-app-dist:
     name: Upload ADempiere-Vue binaries
+    # TODO: Does not support edit release: {"resource":"Release","code":"already_exists","field":"tag_name"}
+    if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
     needs:
       - build-app
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,49 +88,19 @@ jobs:
       - build-app
     runs-on: ubuntu-latest
     outputs:
-      is_have_secrets: ${{ steps.check_secret_job.outputs.have_secrets }}
+      is_have_secrets: ${{ steps.check_secret_job.outputs.is_have_secrets }}
     steps:
       - id: check_secret_job
         run: |
-          if [[ "${{ secrets.DOCKER_USERNAME }}" != "" ]]; \
+          if [[ "${{ secrets.DOCKER_REPO_FRONTEND }}" != "" && \
+                "${{ secrets.DOCKER_USERNAME }}" != "" && \
+                "${{ secrets.DOCKER_TOKEN }}" != "" ]]; \
           then
-            echo "Secrets to use a container registry were configured in the repo"
+            echo "Secrets to use a container registry are configured in the repo"
             echo "::set-output name=is_have_secrets::true"
           else
             echo "Secrets to use a container registry were not configured in the repo"
             echo "::set-output name=is_have_secrets::false"
-          fi
-
-  # Check secrets to push image in docker hub registry
-  check-docker-secrets-token:
-    name: Check if docker hub registry information was set on secrets
-    needs:
-      - build-app
-    runs-on: ubuntu-latest
-    steps:
-      - id: check_secret_job
-        run: |
-          if [[ "${{ secrets.DOCKER_TOKEN }}" != null ]]; \
-          then
-            echo "Secrets to use a container registry were configured in the repo"
-          else
-            echo "Secrets to use a container registry were not configured in the repo"
-          fi
-
-  # Check secrets to push image in docker hub registry
-  check-docker-secrets-repo:
-    name: Check if docker hub registry information was set on secrets
-    needs:
-      - build-app
-    runs-on: ubuntu-latest
-    steps:
-      - id: check_secret_job
-        run: |
-          if [[ "${{ secrets.DOCKER_REPO_FRONTEND }}" != "" ]]; \
-          then
-            echo "Secrets to use a container registry were configured in the repo"
-          else
-            echo "Secrets to use a container registry were not configured in the repo"
           fi
 
   # Publish docker image in Docker Hub registry to application

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,11 +79,35 @@ jobs:
         with:
           args: 'Adempiere-Vue.zip'
 
+  # Check secrets to push image in docker hub registry
+  check-docker-secrets:
+    name: Check if docker hub registry information was set on secrets
+    needs:
+      - build-app
+    runs-on: ubuntu-latest
+    outputs:
+      is_have_secrets: ${{ steps.check_secret_job.outputs.have_secrets }}
+    steps:
+      - id: check_secret_job
+        run: |
+          if [[ "${{ secrets.DOCKER_REPO_FRONTEND }}" != "" && \
+                "${{ secrets.DOCKER_USERNAME }}" != "" && \
+                "${{ secrets.DOCKER_TOKEN }}" != "" ]]; \
+          then
+            echo "Secrets to use a container registry were configured in the repo"
+            echo "::set-output name=is_have_secrets::true"
+          else
+            echo "Secrets to use a container registry were not configured in the repo"
+            echo "::set-output name=is_have_secrets::false"
+          fi
+
   # Publish docker image in Docker Hub registry to application
   push-imame-dhr:
     name: Push Docker image to Docker Hub
     needs:
-      - build-app
+      - check-docker-secrets
+    # Skip step based on secret
+    if: needs.check-docker-secrets.outputs.is_have_secrets == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/README.es.md
+++ b/README.es.md
@@ -90,14 +90,14 @@ Ejecución de Contenedor:
 docker run -it \
 	--name adempiere-vue \
 	-p 80:80 \
-	-e API_URL="https://api.erpya.com" \
+	-e API_URL="http://localhost:8085" \
 	erpya/adempiere-vue
 ```
 
 
 ### Variables de entorno para la configuración
 
- * `API_URL`: Indica la dirección URL del servidor con el que se comunicará por defecto el cliente web [Proxy-Adempiere-Api](https://github.com/adempiere/proxy-adempiere-api), el valor por defecto es `https://https://api.erpya.com`.
+ * `API_URL`: Indica la dirección URL del servidor con el que se comunicará por defecto el cliente web [Proxy-Adempiere-Api](https://github.com/adempiere/proxy-adempiere-api), el valor por defecto es `http://localhost:8085`.
 
 NOTA: Si no cambias los valores de esta variable de entorno, no es necesario indicarlo en el comando `docker run`, por defecto colocará el valor que se encuentra predeterminado.
 

--- a/README.md
+++ b/README.md
@@ -107,14 +107,14 @@ Run container container:
 docker run -it \
 	--name adempiere-vue \
 	-p 80:80 \
-	-e API_URL="https://api.erpya.com" \
+	-e API_URL="http://localhost:8085" \
 	erpya/adempiere-vue
 ```
 
 
 ### Environment variables for the configuration
 
- * `API_URL`: It indicates the address of the server to which you will point the service [Proxy-Adempiere-Api](https://github.com/adempiere/proxy-adempiere-api), by default its value is `https://https://api.erpya.com`.
+ * `API_URL`: It indicates the address of the server to which you will point the service [Proxy-Adempiere-Api](https://github.com/adempiere/proxy-adempiere-api), by default its value is `http://localhost:8085`.
 
 NOTE: If you do not change the values of the environment variables, it is not necessary to indicate them in the `docker run` command, since the default values will be set.
 

--- a/build/Dockerfile.prod
+++ b/build/Dockerfile.prod
@@ -5,7 +5,7 @@ LABEL maintainer="Elsiosanches@gmail.com; EdwinBetanc0urt@outlook.com;" \
 	description="ADempiere-Vue."
 
 
-ENV API_URL="https://api.erpya.com"
+ENV API_URL="http://localhost:8085"
 
 COPY build/start.sh .
 COPY dist/ /usr/share/nginx/html/

--- a/build/start.sh
+++ b/build/start.sh
@@ -4,7 +4,7 @@
 cd /usr/share/nginx/html/static/js
 
 # Set API Proxy connection
-find -name 'app.*.js' -exec sed -i "s|https://api.erpya.com|$API_URL|g" {} \;
+find -name 'app.*.js' -exec sed -i "s|http://localhost:8085|$API_URL|g" {} \;
 
 # Start nginx web server
 nginx && tail -f /dev/null

--- a/config/default.json
+++ b/config/default.json
@@ -5,14 +5,14 @@
   },
   "adempiere": {
     "api": {
-      "url": "https://api.erpya.com/api/adempiere/",
+      "url": "http://localhost:8085/api/adempiere/",
       "timeout": 10000
     },
     "images": {
-      "url": "https://api.erpya.com/adempiere-api/img/"
+      "url": "http://localhost:8085/adempiere-api/img/"
     },
     "resource": {
-      "url": "https://api.erpya.com/adempiere-api/"
+      "url": "http://localhost:8085/adempiere-api/"
     }
   },
   "repository": {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

Change default value on docker enviroment variable `API_URL` to http://localhost:8085.

### Steps to reproduce

1. Create a release.
2. Pull docker image with release version.
3. Run container.

### Screenshots:

#### Before this changes:

![Screenshot_20220620_023254](https://user-images.githubusercontent.com/20288327/174539368-d45b71ea-ab86-404c-856c-2a98c0717146.png)

See: https://github.com/EdwinBetanc0urt/adempiere-vue/runs/6921888554?check_suite_focus=true
`
Run docker/login-action@v2
Error: Username and password required
`

#### After this changes:
Without secrets configured:

![Screenshot_20220620_023626](https://user-images.githubusercontent.com/20288327/174539970-a9a77198-3ccb-4418-b210-8e3105e48939.png)

With secrets configured:

![Screenshot_20220620_023453](https://user-images.githubusercontent.com/20288327/174539606-2faaf322-b074-43e2-83f5-48c8f0f9b419.png)

See: https://github.com/EdwinBetanc0urt/adempiere-vue/actions/runs/2527035172

### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
This to prevent errors in actions, conditional was added to evaluate if there are any secrets about publishing in docker hub:
* `DOCKER_REPO_FRONTEND`
* `DOCKER_USERNAME`
* `DOCKER_TOKEN`

