### PR TITLE
feat: Run process add record as parameter.

### DIFF
--- a/src/api/ADempiere/process.js
+++ b/src/api/ADempiere/process.js
@@ -21,7 +21,6 @@ import { request } from '@/utils/ADempiere/request'
  * Request a process
  * This function allows follow structure:
  * @param {string}  uuid, uuid from process to run
- * @param {string}  reportType, format to output report (pdf, html, csv, ...)
  * @param {string}  tableName, table name of tab, used only window
  * @param {number}  recordId, record identifier, used only window
  * @param {string}  recordUuid, record universal unique identifier, used only window
@@ -31,23 +30,16 @@ import { request } from '@/utils/ADempiere/request'
           selectionId,
           selectionValues: [{ columnName, value }]
       }]
- * @param {string}  printFormatUuid
- * @param {boolean} isSummary
  * @param {number}  tableSelectedId, used only browser // TODO: Add support on adempiere-vue
- * @param {string}  reportViewUuid
  */
 export function requestRunProcess({
   uuid,
-  reportType,
   tableName,
   recordId,
   recordUuid,
   parametersList = [],
   selectionsList = [],
-  isSummary,
-  tableSelectedId,
-  printFormatUuid,
-  reportViewUuid
+  tableSelectedId
 }) {
   parametersList = parametersList.map(parameter => {
     return {
@@ -64,13 +56,9 @@ export function requestRunProcess({
       table_name: tableName,
       id: recordId,
       uuid: recordUuid,
-      is_summary: isSummary,
-      report_type: reportType,
       table_selected_id: tableSelectedId,
-      report_view_uuid: reportViewUuid,
       parameters: parametersList,
-      selections: selectionsList,
-      print_format_uuid: printFormatUuid
+      selections: selectionsList
     }
   })
     .then(processRunResponse => {

--- a/src/api/ADempiere/report.js
+++ b/src/api/ADempiere/report.js
@@ -18,6 +18,59 @@
 import { request } from '@/utils/ADempiere/request'
 
 /**
+ * Request a Generate Report
+ * This function allows follow structure:
+ * @param {string}  uuid, uuid from report to run
+ * @param {string}  reportType, format to output report (pdf, html, csv, ...)
+ * @param {string}  tableName, table name of tab, used only window
+ * @param {number}  recordId, record identifier, used only window
+ * @param {string}  recordUuid, record universal unique identifier, used only window
+ * @param {array}   parametersList, parameters from process [{ columnName, value }]
+ * @param {string}  printFormatUuid
+ * @param {boolean} isSummary
+ * @param {string}  reportViewUuid
+ */
+export function requestGenerateReport({
+  uuid,
+  reportType,
+  tableName,
+  recordId,
+  recordUuid,
+  parametersList = [],
+  isSummary,
+  printFormatUuid,
+  reportViewUuid
+}) {
+  parametersList = parametersList.map(parameter => {
+    return {
+      key: parameter.columnName,
+      value: parameter.value
+    }
+  })
+
+  return request({
+    url: '/common/api/process',
+    method: 'post',
+    data: {
+      process_uuid: uuid,
+      table_name: tableName,
+      id: recordId,
+      uuid: recordUuid,
+      is_summary: isSummary,
+      report_type: reportType,
+      report_view_uuid: reportViewUuid,
+      parameters: parametersList,
+      print_format_uuid: printFormatUuid
+    }
+  })
+    .then(reportGeneratedResponse => {
+      const { convertProcessLog } = require('@/utils/ADempiere/apiConverts/process.js')
+
+      return convertProcessLog(reportGeneratedResponse)
+    })
+}
+
+/**
  * Request Pending Documents List
  * @param {string} tableName
  * @param {string} uuid report universally unique identifier

--- a/src/store/modules/ADempiere/dictionary/browser/actions.js
+++ b/src/store/modules/ADempiere/dictionary/browser/actions.js
@@ -35,7 +35,7 @@ import {
   refreshBrowserSearh, runProcessOfBrowser,
   zoomWindow, runDeleteable
 } from '@/utils/ADempiere/dictionary/browser.js'
-import { showNotification } from '@/utils/ADempiere/notification.js'
+import { showMessage, showNotification } from '@/utils/ADempiere/notification.js'
 import { isLookup } from '@/utils/ADempiere/references'
 
 export default {
@@ -110,6 +110,19 @@ export default {
               containerUuid: process.uuid,
               title: process.name,
               doneMethod: () => {
+                const fieldsList = rootGetters.getStoredFieldsFromProcess(process.uuid)
+                const emptyMandatory = rootGetters.getFieldsListEmptyMandatory({
+                  containerUuid: process.uuid,
+                  fieldsList
+                })
+                if (!isEmptyValue(emptyMandatory)) {
+                  showMessage({
+                    message: language.t('notifications.mandatoryFieldMissing') + emptyMandatory,
+                    type: 'info'
+                  })
+                  return
+                }
+
                 store.dispatch('startProcessOfBrowser', {
                   parentUuid: browserDefinition.uuid,
                   containerUuid: process.uuid

--- a/src/store/modules/ADempiere/modalDialogManager.js
+++ b/src/store/modules/ADempiere/modalDialogManager.js
@@ -28,18 +28,22 @@ const modalDialogManager = {
 
   mutations: {
     setModalDialog(state, {
+      beforeOpen,
       cancelMethod,
       containerUuid,
       componentPath,
+      containerManager,
       doneMethod,
       loadData,
       title,
       isShowed
     }) {
       Vue.set(state.modalDialogManager, containerUuid, {
+        beforeOpen,
         cancelMethod,
         containerUuid,
         componentPath,
+        containerManager,
         doneMethod,
         loadData,
         title,
@@ -66,6 +70,8 @@ const modalDialogManager = {
     setModalDialog({ commit }, {
       containerUuid,
       componentPath,
+      containerManager = {},
+      beforeOpen = function() {},
       doneMethod = function() {},
       cancelMethod = function() {},
       loadData = function() {},
@@ -75,6 +81,8 @@ const modalDialogManager = {
       commit('setModalDialog', {
         containerUuid,
         componentPath,
+        containerManager,
+        beforeOpen,
         doneMethod,
         loadData,
         cancelMethod,

--- a/src/store/modules/ADempiere/processManager.js
+++ b/src/store/modules/ADempiere/processManager.js
@@ -164,17 +164,7 @@ const processManager = {
 
         let isProcessedError = false
         let summary = ''
-        /*
-        // close current page
-        const currentRoute = router.app._route
-        const tabViewsVisited = rootGetters.visitedViews
-        dispatch('tagsView/delView', currentRoute)
-        // go to back page
-        const oldRouter = tabViewsVisited[tabViewsVisited.length - 1]
-        router.push({
-          path: oldRouter.path
-        }, () => {})
-        */
+
         requestRunProcess({
           uuid: containerUuid,
           parametersList,
@@ -219,11 +209,11 @@ const processManager = {
 
     startProcessOfWindows({ commit, dispatch, getters, rootGetters }, {
       parentUuid,
-      containerUuid
+      containerUuid,
+      tableName,
+      recordUuid
     }) {
       return new Promise(resolve => {
-        const recordId = router.app._route.query.recordId
-        const recordUuid = router.app._route.query.action
         const windowsUuid = router.app._route.meta.uuid
         const browserDefinition = getters.getStoredTab(windowsUuid, parentUuid)
         const processModal = getters.getModalDialogManager({
@@ -231,7 +221,6 @@ const processManager = {
         })
         const currentProcess = browserDefinition.processes.find(process => process.name === processModal.title)
 
-        // })
         const fieldsList = getters.getStoredFieldsFromProcess(containerUuid)
         const parametersList = rootGetters.getProcessParameters({
           containerUuid,
@@ -256,18 +245,19 @@ const processManager = {
         requestRunProcess({
           uuid: containerUuid,
           parametersList,
-          recordUuid,
-          recordId
+          tableName,
+          recordUuid
         })
           .then(runProcessRepsonse => {
             isProcessedError = runProcessRepsonse.isError
             summary = runProcessRepsonse.summary
 
+            // TODO: Update record on window
             resolve(runProcessRepsonse)
           })
           .catch(error => {
             isProcessedError = true
-            console.warn(`Error getting print formats: ${error.message}. Code: ${error.code}.`)
+            console.warn(`Error executing process: ${error.message}. Code: ${error.code}.`)
           })
           .finally(() => {
             // commit('resetStateWindowManager', {

--- a/src/store/modules/ADempiere/reportManager.js
+++ b/src/store/modules/ADempiere/reportManager.js
@@ -20,9 +20,7 @@ import language from '@/lang'
 
 // api request methods
 import {
-  requestRunProcess as requestRunReport
-} from '@/api/ADempiere/process.js'
-import {
+  requestGenerateReport,
   requestListPrintFormats,
   requestListReportsViews,
   requestListDrillTables,
@@ -87,11 +85,11 @@ const reportManager = {
       containerUuid,
       reportType = DEFAULT_REPORT_TYPE,
       printFormatUuid,
-      reportViewUuid
+      reportViewUuid,
+      tableName,
+      recordUuid
     }) {
       return new Promise(resolve => {
-        const recordId = router.app._route.params.recordId
-        const tableName = router.app._route.params.recordId
         const reportDefinition = rootGetters.getStoredReport(containerUuid)
         const { fieldsList } = reportDefinition
 
@@ -125,26 +123,28 @@ const reportManager = {
           })
         }
 
-        // close current page
-        const currentRoute = router.app._route
-        const tabViewsVisited = rootGetters.visitedViews
-        dispatch('tagsView/delView', currentRoute)
-        // go to back page
-        const oldRouter = tabViewsVisited[tabViewsVisited.length - 1]
-        if (!isEmptyValue(oldRouter)) {
-          router.push({
-            path: oldRouter.path
-          }, () => {})
+        if (isEmptyValue(recordUuid)) {
+          // close current page
+          const currentRoute = router.app._route
+          const tabViewsVisited = rootGetters.visitedViews
+          dispatch('tagsView/delView', currentRoute)
+          // go to back page
+          const oldRouter = tabViewsVisited[tabViewsVisited.length - 1]
+          if (!isEmptyValue(oldRouter)) {
+            router.push({
+              path: oldRouter.path
+            }, () => {})
+          }
         }
 
-        requestRunReport({
+        requestGenerateReport({
           uuid: containerUuid,
           reportType,
-          tableName,
           parametersList,
           printFormatUuid,
-          recordId,
-          reportViewUuid
+          reportViewUuid,
+          tableName,
+          recordUuid
         })
           .then(runReportRepsonse => {
             const { instanceUuid, output, isError } = runReportRepsonse
@@ -245,7 +245,7 @@ const reportManager = {
           })
         }
 
-        requestRunReport({
+        requestGenerateReport({
           uuid: containerUuid,
           reportType,
           parametersList

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -183,7 +183,9 @@ export const runProcessOfWindow = {
   actionName: 'runProcessOfWindow',
   runProcessOfWindow: ({ parentUuid, containerUuid, uuid }) => {
     store.commit('setSelectProcessWindows', uuid)
+
     store.commit('setShowedModalDialog', {
+      parentUuid: containerUuid,
       containerUuid: uuid,
       isShowed: true
     })
@@ -204,7 +206,9 @@ export const generateReportOfWindow = {
   actionName: 'generateReportOfWindow',
   generateReportOfWindow: ({ parentUuid, containerUuid, uuid }) => {
     store.commit('setSelectProcessWindows', uuid)
+
     store.commit('setShowedModalDialog', {
+      parentUuid: containerUuid,
       containerUuid: uuid,
       isShowed: true
     })


### PR DESCRIPTION
Add record as parameter from which process or report was executed


https://user-images.githubusercontent.com/20288327/174331971-eb4e5229-2a4c-4f0e-aa55-7245958e3316.mp4

#### Steps to reproduce
1. Login with GardenAdmin.
2. Open `Business Partner` window.
3. Select `Customer` tab.
4. Click in `Open Items` field button.
5. See key column (Business Partner) in report.

#### Additional context
cURL request

```shell
curl 'http://localhost:8085/api/adempiere/common/api/process?token=26bf0542-2a72-4808-8974-9d4927bf077a&language=en' \
  -X POST \
  -H 'Content-Type: application/json' \
  --data-raw '{"process_uuid":"a42cfc20-fb40-11e8-a479-7a0060f0aa01","table_name":"C_BPartner","uuid":"c3cfeb5f-1b2f-4f4b-a16c-d9cda23f59e1","report_type":"pdf","parameters":[{"key":"DaysDue","value":-99999},{"key":"DaysDue_To","value":99999}]}'
```
