### PR TITLE
fix: Report generated as PDF on google chrome.

### DIFF
--- a/src/store/modules/ADempiere/reportManager.js
+++ b/src/store/modules/ADempiere/reportManager.js
@@ -167,7 +167,7 @@ const reportManager = {
               link = buildLinkHref({
                 fileName: output.fileName,
                 outputStream: output.outputStream,
-                type: output.mimeType
+                mimeType: output.mimeType
               })
 
               // donwloaded not support render report

--- a/src/utils/ADempiere/dictionary/report.js
+++ b/src/utils/ADempiere/dictionary/report.js
@@ -47,6 +47,29 @@ export const reportFormatsList = [
 ]
 
 /**
+ * Documents mime type
+ */
+export const mimeTypeOfReport = {
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  dot: 'application/msword',
+  dotx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
+  csv: 'text/csv;charset=utf-8',
+  htm: 'text/html;charset=utf-8',
+  html: 'text/html;charset=utf-8',
+  md: 'text/markdown;charset=utf-8',
+  odt: 'application/vnd.oasis.opendocument.text',
+  pdf: 'application/pdf',
+  ps: 'application/postscript',
+  rtf: 'application/rtf',
+  ssv: 'application/vnd.shade-save-file',
+  txt: 'text/plain;charset=utf-8',
+  xls: 'application/vnd.ms-excel; ',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  xml: 'application/xml'
+}
+
+/**
  * Default report type to generate
  */
 export const DEFAULT_REPORT_TYPE = 'pdf'

--- a/src/utils/ADempiere/resource.js
+++ b/src/utils/ADempiere/resource.js
@@ -19,6 +19,8 @@
 // Please add the necessary functions here:
 import { config } from '@/utils/ADempiere/config'
 import { getToken } from '@/utils/auth'
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
+import { mimeTypeOfReport } from '@/utils/ADempiere/dictionary/report'
 
 /**
  * Extract extension file from file name
@@ -151,6 +153,7 @@ export function buildBlobAndValues({
  * Build link from ouput report
  * @param {string} fileName
  * @param {string} mimeType
+ * @param {string} extension
  * @param {array} outputStream
  * @param {boolean} isDownload
  * @returns link
@@ -158,9 +161,17 @@ export function buildBlobAndValues({
 export function buildLinkHref({
   fileName,
   mimeType,
+  extension,
   outputStream,
   isDownload = false
 }) {
+  if (isEmptyValue(mimeType)) {
+    if (isEmptyValue(extension)) {
+      extension = getExtensionFromFile(fileName)
+    }
+    mimeType = mimeTypeOfReport[extension]
+  }
+
   const { blobFile } = buildBlobAndValues({
     mimeType,
     outputStream


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `GardenAdmin`.
2. Generate `Open Items` report with PDF report type.

The report as generated with unicode characters.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/174662765-a9c80192-a111-4394-8843-c5954263c7d3.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/174662803-af19262f-524e-4ec4-8087-beb9f54bdb3e.mp4


#### Expected behavior
The PDF document is expected to be generated in a readable form.


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Google Chrome 102.0.5005.115.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.


#### Additional context
This only occurs with Chromiun-based browsers, including `Brave`, `Opera` and `Microsoft Edge`.

In `Mozilla Firefox` browser it works correctly

solop-develop/frontend-core#41 
