### PR TITLE
fix: Read only field button.

### DIFF
--- a/src/utils/ADempiere/dictionary/process.js
+++ b/src/utils/ADempiere/dictionary/process.js
@@ -28,6 +28,7 @@ import { isHiddenField } from '@/utils/ADempiere/references'
  * @param {number} displayType
  * @param {boolean} isActive
  * @param {boolean} isDisplayed
+ * @param {string} displayLogic
  * @param {boolean} isDisplayedFromLogic
  * @returns {boolean}
  */
@@ -43,22 +44,22 @@ export function isDisplayedField({ displayType, isActive, isDisplayed, displayLo
 
 /**
  * Process manager mandatory logic
+ * TODO: Add support on ADempiere core to mandatory logic
  * @param {boolean} isMandatory
- * @param {boolean} isMandatoryFromLogic
  * @returns {boolean}
  */
-export function isMandatoryField({ isMandatory, isMandatoryFromLogic }) {
-  return isMandatory || isMandatoryFromLogic
+export function isMandatoryField({ isMandatory }) {
+  return isMandatory
 }
 
 /**
  * Process is read only field
- * @param {boolean} isReadOnly
+ * @param {string} readOnlyLogic
  * @param {boolean} isReadOnlyFromLogic
  * @returns {boolean}
  */
-export function isReadOnlyField({ isReadOnly, isReadOnlyFromLogic }) {
-  return isReadOnly && isReadOnlyFromLogic
+export function isReadOnlyField({ readOnlyLogic, isReadOnlyFromLogic }) {
+  return !isEmptyValue(readOnlyLogic) && isReadOnlyFromLogic
 }
 
 /**

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -50,8 +50,8 @@ export function isDisplayedField({ isDisplayed, displayLogic, isDisplayedFromLog
  * @param {boolean} isMandatoryFromLogic
  * @returns {boolean}
  */
-export function isMandatoryField({ isMandatory, isMandatoryFromLogic }) {
-  return isMandatory || isMandatoryFromLogic
+export function isMandatoryField({ isMandatory, mandatoryLogic, isMandatoryFromLogic }) {
+  return isMandatory || (!isEmptyValue(mandatoryLogic) && isMandatoryFromLogic)
 }
 
 /**
@@ -60,8 +60,8 @@ export function isMandatoryField({ isMandatory, isMandatoryFromLogic }) {
  * @param {boolean} isReadOnlyFromLogic
  * @returns {boolean}
  */
-export function isReadOnlyField({ isReadOnly, isReadOnlyFromLogic }) {
-  return isReadOnly || isReadOnlyFromLogic
+export function isReadOnlyField({ isReadOnly, readOnlyLogic, isReadOnlyFromLogic }) {
+  return isReadOnly || (!isEmptyValue(readOnlyLogic) && isReadOnlyFromLogic)
 }
 
 /**
@@ -78,8 +78,8 @@ export function isDisplayedColumn({ isDisplayed, isDisplayedGrid, isDisplayedFro
     (isEmptyValue(displayLogic) || isDisplayedFromLogic)
 }
 
-export function isMandatoryColumn({ isMandatory, isMandatoryFromLogic }) {
-  return isMandatory || isMandatoryFromLogic
+export function isMandatoryColumn({ isMandatory, mandatoryLogic, isMandatoryFromLogic }) {
+  return isMandatory || (!isEmptyValue(mandatoryLogic) && isMandatoryFromLogic)
 }
 
 export function isReadOnlyColumn({ isReadOnly }) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Business Partner` window.
2. Show `Link Organization` field button.
3. Find record with `Link Organization`.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/175047020-94607ba7-d410-48f2-8850-cf69e4e5a1f3.mp4



#### Expected behavior
Note how the button type field when having a record in that field is set to read only.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
TODO: Add displayed value support on backend.