### PR TITLE
feat: Showed default fields.

### DIFF
--- a/src/lang/ADempiere/es/fieldDisplayOptions.js
+++ b/src/lang/ADempiere/es/fieldDisplayOptions.js
@@ -17,7 +17,7 @@
 const fieldsDisplayOptions = {
   // fields showed options
   minimalistView: 'Vista Minimalista.',
-  showOAllFields: 'Mostrar Todos Los Campos.',
+  showAllFields: 'Mostrar Todos Los Campos.',
   showFieldsWithValue: 'Mostrar Campos Con Valor Por Defecto.',
   Show2Columns: 'Mostrar 2 Columnas',
   Show3Columns: 'Mostrar 3 Columnas',

--- a/src/store/modules/ADempiere/dictionary/browser/actions.js
+++ b/src/store/modules/ADempiere/dictionary/browser/actions.js
@@ -32,6 +32,7 @@ import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { generatePanelAndFields } from '@/utils/ADempiere/dictionary/panel.js'
 import {
   isDisplayedField, isMandatoryField,
+  evaluateDefaultFieldShowed,
   refreshBrowserSearh, runProcessOfBrowser,
   zoomWindow, runDeleteable
 } from '@/utils/ADempiere/dictionary/browser.js'
@@ -54,11 +55,11 @@ export default {
               ...browserResponse,
               isShowedCriteria: true
             },
-            isAddFieldsRange: true,
             fieldOverwrite: {
               isShowedFromUser: false
             },
-            sortField: 'seqNoGrid'
+            sortField: 'seqNoGrid',
+            evaluateDefaultFieldShowed
           })
 
           browserDefinition.elementsList = {}

--- a/src/store/modules/ADempiere/dictionary/browser/getters.js
+++ b/src/store/modules/ADempiere/dictionary/browser/getters.js
@@ -154,6 +154,55 @@ export default {
     }
 
     return fieldsEmpty
+  },
+
+  /**
+   * Available fields to showed/hidden
+   * to show, used in components FilterFields
+   * @param {string} containerUuid
+   * @param {array} fieldsList
+   * @param {function} showedMethod
+   * @param {boolean} isEvaluateShowed
+   * @param {boolean} isEvaluateDefaultValue
+   */
+  getBrowserFieldsListToHidden: (state, getters) => ({
+    containerUuid,
+    isTable = false,
+    fieldsList = [],
+    showedMethod = isDisplayedField,
+    isEvaluateDefaultValue = false,
+    isEvaluateShowed = true
+  }) => {
+    if (isEmptyValue(fieldsList)) {
+      fieldsList = getters.getStoredFieldsFromReport(containerUuid)
+    }
+
+    // all optionals (not mandatory) fields
+    const a = fieldsList
+      .filter(fieldItem => {
+        const { defaultValue } = fieldItem
+
+        if (fieldItem.isMandatory && !isTable) {
+          return false
+        }
+
+        if (isEvaluateDefaultValue && isEvaluateShowed) {
+          return showedMethod(fieldItem) &&
+            !isEmptyValue(defaultValue)
+        }
+
+        if (isEvaluateDefaultValue) {
+          return !isEmptyValue(defaultValue)
+        }
+
+        if (isEvaluateShowed) {
+          return showedMethod(fieldItem)
+        }
+
+        return true
+      })
+    console.log(a)
+    return a
   }
 
 }

--- a/src/store/modules/ADempiere/dictionary/report/getters.js
+++ b/src/store/modules/ADempiere/dictionary/report/getters.js
@@ -143,6 +143,53 @@ export default {
     })
 
     return reportParameters
+  },
+
+  /**
+   * Available fields to showed/hidden
+   * to show, used in components FilterFields
+   * @param {string} containerUuid
+   * @param {array} fieldsList
+   * @param {function} showedMethod
+   * @param {boolean} isEvaluateShowed
+   * @param {boolean} isEvaluateDefaultValue
+   */
+  getReportParametersListToHidden: (state, getters) => ({
+    containerUuid,
+    isTable = false,
+    fieldsList = [],
+    showedMethod = isDisplayedField,
+    isEvaluateDefaultValue = false,
+    isEvaluateShowed = true
+  }) => {
+    if (isEmptyValue(fieldsList)) {
+      fieldsList = getters.getStoredFieldsFromReport(containerUuid)
+    }
+
+    // all optionals (not mandatory) fields
+    return fieldsList
+      .filter(fieldItem => {
+        const { defaultValue } = fieldItem
+
+        if (fieldItem.isMandatory && !isTable) {
+          return false
+        }
+
+        if (isEvaluateDefaultValue && isEvaluateShowed) {
+          return showedMethod(fieldItem) &&
+            !isEmptyValue(defaultValue)
+        }
+
+        if (isEvaluateDefaultValue) {
+          return !isEmptyValue(defaultValue)
+        }
+
+        if (isEvaluateShowed) {
+          return showedMethod(fieldItem)
+        }
+
+        return true
+      })
   }
 
 }

--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -41,9 +41,10 @@ import {
   sharedLink,
   recordAccess
 } from '@/utils/ADempiere/constants/actionsMenuList.js'
-import evaluator, { getContext, getContextAttributes } from '@/utils/ADempiere/contextUtils.js'
+import evaluator from '@/utils/ADempiere/evaluator'
+import { getContext, getContextAttributes } from '@/utils/ADempiere/contextUtils.js'
 import { showMessage } from '@/utils/ADempiere/notification'
-import mixinReport from '@/views/ADempiere/Report/mixinReport'
+import { containerManager as containerManagerReport } from '@/utils/ADempiere/dictionary/report'
 
 export default {
   addWindow({ commit, dispatch }, windowResponse) {
@@ -110,12 +111,10 @@ export default {
             ...generateReportOfWindow
           }
 
-          const { containerManager } = mixinReport(process.uuid)
-
           dispatch('setModalDialog', {
             containerUuid: process.uuid,
             title: process.name,
-            containerManager,
+            containerManager: containerManagerReport,
             doneMethod: () => {
               const fieldsList = rootGetters.getReportParameters({
                 containerUuid: process.uuid

--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -300,6 +300,59 @@ export default {
       return attributesList
     }
     return attributesObject
+  },
+
+  /**
+   * Available fields to showed/hidden
+   * to show, used in components FilterFields
+   * @param {string} containerUuid
+   * @param {array} fieldsList
+   * @param {function} showedMethod
+   * @param {boolean} isEvaluateShowed
+   * @param {boolean} isEvaluateDefaultValue
+   */
+  getTabFieldsListToHidden: (state, getters) => ({
+    parentUuid,
+    containerUuid,
+    isTable = false,
+    fieldsList = [],
+    showedMethod = isDisplayedField,
+    isEvaluateDefaultValue = false,
+    isEvaluateShowed = true
+  }) => {
+    if (isEmptyValue(fieldsList)) {
+      fieldsList = getters.getStoredFieldsFromTab(parentUuid, containerUuid)
+    }
+
+    // all optionals (not mandatory) fields
+    return fieldsList
+      .filter(fieldItem => {
+        const { defaultValue } = fieldItem
+        const isMandatory = fieldItem.isMandatory || fieldItem.isMandatoryFromLogic
+
+        // parent column
+        if (fieldItem.isParent) {
+          return true
+        }
+        if (isMandatory && isEmptyValue(defaultValue) && !isTable) {
+          return false
+        }
+
+        if (isEvaluateDefaultValue && isEvaluateShowed) {
+          return showedMethod(fieldItem) &&
+            !isEmptyValue(defaultValue)
+        }
+
+        if (isEvaluateDefaultValue) {
+          return !isEmptyValue(defaultValue)
+        }
+
+        if (isEvaluateShowed) {
+          return showedMethod(fieldItem)
+        }
+
+        return true
+      })
   }
 
 }

--- a/src/store/modules/ADempiere/panel/actions.js
+++ b/src/store/modules/ADempiere/panel/actions.js
@@ -19,7 +19,8 @@ import {
   typeValue
 } from '@/utils/ADempiere/valueUtils.js'
 import { convertObjectToKeyValue } from '@/utils/ADempiere/valueFormat.js'
-import evaluator, { getContext, parseContext } from '@/utils/ADempiere/contextUtils.js'
+import evaluator from '@/utils/ADempiere/evaluator'
+import { getContext, parseContext } from '@/utils/ADempiere/contextUtils'
 import { fieldIsDisplayed } from '@/utils/ADempiere/dictionaryUtils.js'
 import { assignedGroup } from '@/utils/ADempiere/dictionary/panel'
 import router from '@/router'

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -24,22 +24,20 @@ import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { convertBooleanToString } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 import evaluator from '@/utils/ADempiere/evaluator'
 
-export default evaluator
-
 /**
  * Prefix context of global prefix (#)
  */
-export const GLOBAL_CONTEXT_PREFIX = evaluator.GLOBAL_CONTEXT_PREFIX
+export const GLOBAL_CONTEXT_PREFIX = '#' // evaluator.GLOBAL_CONTEXT_PREFIX
 
 /**
  * Prefix context of accounting prefix ($)
  */
-export const ACCOUNTING_CONTEXT_PREFIX = evaluator.ACCOUNTING_CONTEXT_PREFIX
+export const ACCOUNTING_CONTEXT_PREFIX = '$' // evaluator.ACCOUNTING_CONTEXT_PREFIX
 
 /**
  * Prefix context of preference prefix (P|)
  */
-export const PREFERENCE_CONTEXT_PREFIX = evaluator.PREFERENCE_CONTEXT_PREFIX
+export const PREFERENCE_CONTEXT_PREFIX = 'P|' // evaluator.PREFERENCE_CONTEXT_PREFIX
 
 /**
  * Get context state from vuex store

--- a/src/utils/ADempiere/dictionary/browser.js
+++ b/src/utils/ADempiere/dictionary/browser.js
@@ -37,6 +37,19 @@ export function isDisplayedField({ displayType, isActive, isQueryCriteria, displ
 }
 
 /**
+ * Default showed field from user
+ */
+export function evaluateDefaultFieldShowed({ defaultValue, isMandatory, isShowedFromUser }) {
+  if (isMandatory || !isEmptyValue(defaultValue)) {
+    return true
+  }
+  if (isShowedFromUser) {
+    return true
+  }
+  return false
+}
+
+/**
  * Smart Browser not manager mandatory logic, used as query
  * @param {boolean} isMandatoryFromLogic
  * @returns {boolean}
@@ -232,6 +245,15 @@ export const containerManager = {
   getFieldsList({ containerUuid }) {
     return store.getters.getStoredFieldsFromBrowser(containerUuid)
   },
+  getFieldsToHidden: ({ containerUuid, showedMethod, isEvaluateDefaultValue, isTable, fieldsList }) => {
+    return store.getters.getBrowserFieldsListToHidden({
+      containerUuid,
+      fieldsList,
+      showedMethod,
+      isEvaluateDefaultValue,
+      isTable
+    })
+  },
 
   actionPerformed({ field, value, valueTo, containerUuid }) {
     return store.dispatch('browserActionPerformed', {
@@ -253,6 +275,13 @@ export const containerManager = {
    * Is displayed field in panel single record
    */
   isDisplayedField,
+  isDisplayedDefault: ({ isMandatory, defaultValue }) => {
+    // add is showed from user
+    if (isMandatory || !isEmptyValue(defaultValue)) {
+      return true
+    }
+    return false
+  },
 
   isMandatoryField,
 

--- a/src/utils/ADempiere/dictionary/panel.js
+++ b/src/utils/ADempiere/dictionary/panel.js
@@ -18,6 +18,7 @@
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { generateField } from '@/utils/ADempiere/dictionaryUtils.js'
 import { getFieldTemplate } from '@/utils/ADempiere/lookupFactory.js'
+import { isAddRangeField } from '@/utils/ADempiere/references'
 
 /**
  * Order the fields, then assign the groups to each field, and finally group
@@ -116,7 +117,6 @@ export function assignedGroup({
  * @param {string} parentUuid
  * @param {string} containerUuid
  * @param {object} panelMetadata
- * @param {boolean} isAddFieldsRange
  * @param {boolean} isAddFieldUuid
  * @param {boolean} isAddLinkColumn
  * @param {object} fieldOverwrite
@@ -126,11 +126,11 @@ export function generatePanelAndFields({
   parentUuid,
   containerUuid,
   panelMetadata = {},
-  isAddFieldsRange = false,
   isAddFieldUuid = false,
   isAddLinkColumn = false,
   fieldOverwrite = {},
-  sortField = 'sequence' //  sequence, sortNo, seqNoGrid
+  sortField = 'sequence', //  sequence, sortNo, seqNoGrid,
+  evaluateDefaultFieldShowed
 }) {
   const fieldAdditionalAttributes = {
     parentUuid,
@@ -153,6 +153,7 @@ export function generatePanelAndFields({
   let fieldsList = panelMetadata.fields.map((fieldItem, index) => {
     const fieldDefinition = generateField({
       fieldToGenerate: fieldItem,
+      evaluateDefaultFieldShowed,
       moreAttributes: {
         ...fieldAdditionalAttributes,
         fieldsListIndex: index
@@ -175,9 +176,10 @@ export function generatePanelAndFields({
     }
 
     // Add new field if is range number
-    if (isAddFieldsRange && fieldDefinition.isRange && componentPath === 'FieldNumber') {
+    if (isAddRangeField(fieldDefinition)) {
       const fieldRange = generateField({
         fieldToGenerate: fieldItem,
+        evaluateDefaultFieldShowed,
         moreAttributes: fieldAdditionalAttributes,
         typeRange: true
       })

--- a/src/utils/ADempiere/dictionary/process.js
+++ b/src/utils/ADempiere/dictionary/process.js
@@ -21,7 +21,7 @@ import store from '@/store'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { generateField } from '@/utils/ADempiere/dictionaryUtils'
 import { sortFields } from '@/utils/ADempiere/dictionary/panel'
-import { isHiddenField } from '@/utils/ADempiere/references'
+import { isAddRangeField, isHiddenField } from '@/utils/ADempiere/references'
 
 /**
  * Is displayed field parameter in process/report panel
@@ -40,6 +40,20 @@ export function isDisplayedField({ displayType, isActive, isDisplayed, displayLo
 
   // verify if field is active
   return isActive && isDisplayed && (isEmptyValue(displayLogic) || isDisplayedFromLogic)
+}
+
+/**
+ * Default showed field from user
+ */
+export function evaluateDefaultFieldShowed({ name, defaultValue, isMandatory, isShowedFromUser }) {
+  if (!isEmptyValue(defaultValue) || isMandatory) {
+    return true
+  }
+
+  if (isShowedFromUser) {
+    return true
+  }
+  return false
 }
 
 /**
@@ -88,14 +102,16 @@ export function generateProcess({
       .map(fieldItem => {
         const field = generateField({
           fieldToGenerate: fieldItem,
-          moreAttributes: additionalAttributes
+          moreAttributes: additionalAttributes,
+          evaluateDefaultFieldShowed
         })
         // Add new field if is range number
-        if (field.isRange && field.componentPath === 'FieldNumber') {
+        if (isAddRangeField(field)) {
           const fieldRange = generateField({
             fieldToGenerate: fieldItem,
             moreAttributes: additionalAttributes,
-            typeRange: true
+            typeRange: true,
+            evaluateDefaultFieldShowed
           })
 
           fieldsRangeList.push(fieldRange)
@@ -143,6 +159,89 @@ export const runProcess = {
   runProcess: ({ containerUuid }) => {
     store.dispatch('startProcess', {
       containerUuid
+    })
+  }
+}
+
+/**
+ * Container manager to Process panel
+ */
+export const containerManager = {
+  getPanel({ containerUuid }) {
+    return store.getters.getStoredProcess(containerUuid)
+  },
+  getFieldsList({ containerUuid }) {
+    return store.getters.getStoredFieldsFromProcess(containerUuid)
+  },
+  getFieldsToHidden: ({ parentUuid, containerUuid, fieldsList, showedMethod, isEvaluateDefaultValue, isTable }) => {
+    return store.getters.getProcessParametersListToHidden({
+      parentUuid,
+      containerUuid,
+      fieldsList,
+      showedMethod,
+      isEvaluateDefaultValue,
+      isTable
+    })
+  },
+
+  actionPerformed: ({ field, value }) => {
+    // store.dispatch('processActionPerformed', {
+    //   field,
+    //   value
+    // })
+  },
+
+  setDefaultValues: ({ containerUuid }) => {
+    store.dispatch('setProcessDefaultValues', {
+      containerUuid
+    })
+  },
+
+  isDisplayedField,
+  isDisplayedDefault: ({ isMandatory, defaultValue }) => {
+    // add is showed from user
+    if (isMandatory || !isEmptyValue(defaultValue)) {
+      return true
+    }
+    return false
+  },
+
+  isReadOnlyField,
+
+  isMandatoryField,
+
+  changeFieldShowedFromUser({ containerUuid, fieldsShowed }) {
+    store.dispatch('changeProcessFieldShowedFromUser', {
+      containerUuid,
+      fieldsShowed
+    })
+  },
+
+  /**
+   * @returns Promisse with value and displayedValue
+   */
+  getDefaultValue({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName, value }) {
+    return store.dispatch('getDefaultValueFromServer', {
+      parentUuid,
+      containerUuid,
+      contextColumnNames,
+      processParameterUuid: uuid,
+      id,
+      //
+      columnName,
+      value
+    })
+  },
+  getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid, searchValue, isAddBlankValue = false, blankValue }) {
+    return store.dispatch('getLookupListFromServer', {
+      parentUuid,
+      containerUuid,
+      contextColumnNames,
+      processParameterUuid: uuid,
+      searchValue,
+      // app attributes
+      isAddBlankValue,
+      blankValue
     })
   }
 }

--- a/src/utils/ADempiere/dictionary/report.js
+++ b/src/utils/ADempiere/dictionary/report.js
@@ -19,6 +19,9 @@ import store from '@/store'
 
 // utils and helpers methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
+import {
+  containerManager as containerManagerProcess
+} from '@/utils/ADempiere/dictionary/process'
 
 /**
  * Suppoerted render files
@@ -169,6 +172,50 @@ export const changeParameters = {
     store.commit('setShowedModalDialog', {
       containerUuid,
       isShowed: true
+    })
+  }
+}
+
+/**
+ * Container manager to Report panel
+ */
+export const containerManager = {
+  ...containerManagerProcess,
+
+  getPanel({ containerUuid }) {
+    return store.getters.getStoredReport(containerUuid)
+  },
+  getFieldsList({ containerUuid }) {
+    return store.getters.getStoredFieldsFromReport(containerUuid)
+  },
+  getFieldsToHidden: ({ parentUuid, containerUuid, fieldsList, showedMethod, isEvaluateDefaultValue, isTable }) => {
+    return store.getters.getReportParametersListToHidden({
+      parentUuid,
+      containerUuid,
+      fieldsList,
+      showedMethod,
+      isEvaluateDefaultValue,
+      isTable
+    })
+  },
+
+  changeFieldShowedFromUser({ containerUuid, fieldsShowed }) {
+    store.dispatch('changeReportFieldShowedFromUser', {
+      containerUuid,
+      fieldsShowed
+    })
+  },
+
+  actionPerformed: ({ field, value }) => {
+    // store.dispatch('reportActionPerformed', {
+    //   field,
+    //   value
+    // })
+  },
+
+  setDefaultValues: ({ containerUuid }) => {
+    store.dispatch('setReportDefaultValues', {
+      containerUuid
     })
   }
 }

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -46,6 +46,24 @@ export function isDisplayedField({ isDisplayed, displayLogic, isDisplayedFromLog
 }
 
 /**
+ * Default showed field from user
+ */
+export function evaluateDefaultFieldShowed({ defaultValue, isMandatory, isShowedFromUser, isParent }) {
+  if (String(defaultValue).includes('@SQL=')) {
+    return true
+  }
+
+  if (isEmptyValue(defaultValue) && isMandatory && !isParent) {
+    return true
+  }
+
+  if (isShowedFromUser) {
+    return true
+  }
+  return false
+}
+
+/**
  * Tab manager mandatory logic
  * @param {boolean} isMandatoryFromLogic
  * @returns {boolean}
@@ -503,7 +521,8 @@ export function generateTabs({
         isReadOnlyFromForm: true,
         isShowedFromUser: false,
         firstTabUuid
-      }
+      },
+      evaluateDefaultFieldShowed
     })
   })
 
@@ -545,6 +564,16 @@ export const containerManager = {
   getFieldsList: ({ parentUuid, containerUuid }) => {
     return store.getters.getStoredFieldsFromTab(parentUuid, containerUuid)
   },
+  getFieldsToHidden: ({ parentUuid, containerUuid, fieldsList, showedMethod, isEvaluateDefaultValue, isTable }) => {
+    return store.getters.getTabFieldsListToHidden({
+      parentUuid,
+      containerUuid,
+      fieldsList,
+      showedMethod,
+      isEvaluateDefaultValue,
+      isTable
+    })
+  },
 
   actionPerformed: function(eventInfo) {
     console.log('actionPerformed: ', eventInfo)
@@ -573,6 +602,12 @@ export const containerManager = {
   },
 
   isDisplayedField,
+  isDisplayedDefault: ({ isMandatory, isParent, defaultValue, parsedDefaultValue }) => {
+    if (isMandatory && !isParent && isEmptyValue(defaultValue)) {
+      return true
+    }
+    return false
+  },
   isDisplayedColumn,
 
   isReadOnlyField(field) {

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -44,16 +44,13 @@ export function generateField({
   fieldToGenerate,
   moreAttributes,
   typeRange = false,
+  evaluateDefaultFieldShowed = ({ isShowedFromUser }) => {
+    return isShowedFromUser
+  },
   isSOTrxMenu
 }) {
   const { columnName } = fieldToGenerate
-  let isShowedFromUser = false
   let isGetServerValue = false
-  // verify if it no overwrite value with ...moreAttributes
-  if (moreAttributes.isShowedFromUser) {
-    isShowedFromUser = moreAttributes.isShowedFromUser
-  }
-
   let isColumnReadOnlyForm = false
   let isChangedAllForm = false
   let valueIsReadOnlyForm
@@ -129,7 +126,7 @@ export function generateField({
     })
 
     if (String(fieldToGenerate.defaultValue).includes('@SQL=')) {
-      isShowedFromUser = true
+      // isShowedFromUser = true
       isGetServerValue = true
     }
 
@@ -186,8 +183,8 @@ export function generateField({
     dependentFieldsList: [],
     // TODO: Add support on server
     // app attributes
-    isShowedFromUser,
-    isShowedFromUserDefault: isShowedFromUser, // set this value when reset panel
+    isShowedFromUser: false,
+    isShowedFromUserDefault: false, // set this value when reset panel
     isShowedTableFromUser: fieldToGenerate.isDisplayed,
     isFixedTableColumn: false,
     valueType: componentReference.valueType, // value type to convert with gGRPC
@@ -225,18 +222,21 @@ export function generateField({
       field.sortNo = field.sortNo > 0 ? field.sortNo + 1 : 0
 
       // if field with value displayed in main panel
-      if (!isEmptyValue(parsedDefaultValueTo) && (fieldToGenerate.isMandatory || evaluatedLogics.isMandatoryFromLogic)) {
-        field.isShowedFromUser = true
-        field.isShowedFromUserDefault = true
-      }
+      field.isShowedFromUser = evaluateDefaultFieldShowed({
+        ...field,
+        defaultValue: parsedDefaultValueTo
+      })
     }
   }
 
   // if field with value displayed in main panel
-  if (!typeRange && isEmptyValue(fieldToGenerate.defaultValue) && (fieldToGenerate.isMandatory || evaluatedLogics.isMandatoryFromLogic)) {
-    field.isShowedFromUser = true
-    field.isShowedFromUserDefault = true
+  if (!typeRange) {
+    field.isShowedFromUser = evaluateDefaultFieldShowed({
+      ...field,
+      defaultValue: parsedDefaultValue
+    })
   }
+  field.isShowedFromUserDefault = field.isShowedFromUser
 
   // hidden field type button
   if (isHiddenField(field.displayType)) {
@@ -255,7 +255,6 @@ export function generateField({
 export function getEvaluatedLogics({
   parentUuid,
   containerUuid,
-  isDisplayed = true,
   displayLogic,
   mandatoryLogic,
   readOnlyLogic

--- a/src/utils/ADempiere/evaluator.js
+++ b/src/utils/ADempiere/evaluator.js
@@ -34,21 +34,21 @@ import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
  *  - @Name@>J
  *  - Strings may be in single quotes (optional)
  */
-class evaluator {
+export class evaluator {
   /**
    * Prefix context of global prefix (#)
    */
-  static GLOBAL_CONTEXT_PREFIX = `#`
+  static GLOBAL_CONTEXT_PREFIX = '#'
 
   /**
    * Prefix context of accounting prefix ($)
    */
-  static ACCOUNTING_CONTEXT_PREFIX = `$`
+  static ACCOUNTING_CONTEXT_PREFIX = '$'
 
   /**
    * Prefix context of preference prefix (P|)
    */
-  static PREFERENCE_CONTEXT_PREFIX = `P|`
+  static PREFERENCE_CONTEXT_PREFIX = 'P|'
 
   /**
    * Evaluate logic's

--- a/src/views/ADempiere/Report/mixinReport.js
+++ b/src/views/ADempiere/Report/mixinReport.js
@@ -20,79 +20,12 @@ import store from '@/store'
 import lang from '@/lang'
 
 // utils and helper methods
-import {
-  isDisplayedField,
-  isMandatoryField,
-  isReadOnlyField
-} from '@/utils/ADempiere/dictionary/process.js'
+import { containerManager } from '@/utils/ADempiere/dictionary/report'
 
 export default (reportUuid) => {
   const storedReportDefinition = computed(() => {
     return store.getters.getStoredReport(reportUuid)
   })
-
-  const containerManager = {
-    getPanel({ containerUuid }) {
-      return store.getters.getStoredReport(containerUuid)
-    },
-    getFieldsList({ containerUuid }) {
-      return store.getters.getStoredFieldsFromReport(containerUuid)
-    },
-
-    actionPerformed: ({ field, value }) => {
-      // store.dispatch('reportActionPerformed', {
-      //   field,
-      //   value
-      // })
-    },
-
-    setDefaultValues: ({ containerUuid }) => {
-      store.dispatch('setReportDefaultValues', {
-        containerUuid
-      })
-    },
-
-    isDisplayedField,
-
-    isReadOnlyField,
-
-    isMandatoryField,
-
-    changeFieldShowedFromUser({ containerUuid, fieldsShowed }) {
-      store.dispatch('changeReportFieldShowedFromUser', {
-        containerUuid,
-        fieldsShowed
-      })
-    },
-
-    /**
-     * @returns Promisse with value and displayedValue
-     */
-    getDefaultValue({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName, value }) {
-      return store.dispatch('getDefaultValueFromServer', {
-        parentUuid,
-        containerUuid,
-        contextColumnNames,
-        processParameterUuid: uuid,
-        id,
-        //
-        columnName,
-        value
-      })
-    },
-    getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid, searchValue, isAddBlankValue = false, blankValue }) {
-      return store.dispatch('getLookupListFromServer', {
-        parentUuid,
-        containerUuid,
-        contextColumnNames,
-        processParameterUuid: uuid,
-        searchValue,
-        // app attributes
-        isAddBlankValue,
-        blankValue
-      })
-    }
-  }
 
   const actionsList = computed(() => {
     return store.getters.getStoredActionsMenu({


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window.
2. Open any report/process.
3. Open any smart browser.

#### Screenshot or Gif


#### Link to minimal reproduction


https://user-images.githubusercontent.com/20288327/175565344-d4643c59-49c4-40c1-a049-6ec095ae2921.mp4



#### Expected behavior
* Window: By default only mandatory fields and no default value should be displayed.
* Process: By default, only mandatory fields or fields with default value should be displayed.
* Report: By default, only mandatory fields or fields with default value should be displayed.
* Smart Browser: By default, only mandatory fields or fields with default value should be displayed.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

