### PR TITLE
fix: Set parent values on report/process.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/browser/getters.js
+++ b/src/store/modules/ADempiere/dictionary/browser/getters.js
@@ -178,7 +178,7 @@ export default {
     }
 
     // all optionals (not mandatory) fields
-    const a = fieldsList
+    return fieldsList
       .filter(fieldItem => {
         const { defaultValue } = fieldItem
 
@@ -201,8 +201,6 @@ export default {
 
         return true
       })
-    console.log(a)
-    return a
   }
 
 }

--- a/src/store/modules/ADempiere/dictionary/process/getters.js
+++ b/src/store/modules/ADempiere/dictionary/process/getters.js
@@ -135,6 +135,53 @@ export default {
     })
 
     return processParameters
+  },
+
+  /**
+   * Available fields to showed/hidden
+   * to show, used in components FilterFields
+   * @param {string} containerUuid
+   * @param {array} fieldsList
+   * @param {function} showedMethod
+   * @param {boolean} isEvaluateShowed
+   * @param {boolean} isEvaluateDefaultValue
+   */
+  getProcessParametersListToHidden: (state, getters) => ({
+    containerUuid,
+    isTable = false,
+    fieldsList = [],
+    showedMethod = isDisplayedField,
+    isEvaluateDefaultValue = false,
+    isEvaluateShowed = true
+  }) => {
+    if (isEmptyValue(fieldsList)) {
+      fieldsList = getters.getStoredFieldsFromProcess(containerUuid)
+    }
+
+    // all optionals (not mandatory) fields
+    return fieldsList
+      .filter(fieldItem => {
+        const { defaultValue } = fieldItem
+
+        if (fieldItem.isMandatory && !isTable) {
+          return false
+        }
+
+        if (isEvaluateDefaultValue && isEvaluateShowed) {
+          return showedMethod(fieldItem) &&
+            !isEmptyValue(defaultValue)
+        }
+
+        if (isEvaluateDefaultValue) {
+          return !isEmptyValue(defaultValue)
+        }
+
+        if (isEvaluateShowed) {
+          return showedMethod(fieldItem)
+        }
+
+        return true
+      })
   }
 
 }

--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -93,7 +93,7 @@ export default {
       let relatedColumns = []
       const parentColumns = tabDefinition.fieldsList
         .filter(fieldItem => {
-          return fieldItem.isParent || fieldItem.isKey
+          return fieldItem.isParent || fieldItem.isKey || fieldItem.isMandatory
         })
         .map(fieldItem => {
           return fieldItem.columnName

--- a/src/utils/ADempiere/dictionary/browser.js
+++ b/src/utils/ADempiere/dictionary/browser.js
@@ -39,14 +39,14 @@ export function isDisplayedField({ displayType, isActive, isQueryCriteria, displ
 /**
  * Default showed field from user
  */
-export function evaluateDefaultFieldShowed({ defaultValue, isMandatory, isShowedFromUser }) {
-  if (isMandatory || !isEmptyValue(defaultValue)) {
+export function evaluateDefaultFieldShowed({ defaultValue, parsedDefaultValue, isMandatory, isShowedFromUser }) {
+  if (isMandatory) {
     return true
   }
-  if (isShowedFromUser) {
+  if (!isEmptyValue(defaultValue) || !isEmptyValue(parsedDefaultValue)) {
     return true
   }
-  return false
+  return Boolean(isShowedFromUser)
 }
 
 /**

--- a/src/utils/ADempiere/dictionary/process.js
+++ b/src/utils/ADempiere/dictionary/process.js
@@ -45,15 +45,14 @@ export function isDisplayedField({ displayType, isActive, isDisplayed, displayLo
 /**
  * Default showed field from user
  */
-export function evaluateDefaultFieldShowed({ name, defaultValue, isMandatory, isShowedFromUser }) {
-  if (!isEmptyValue(defaultValue) || isMandatory) {
+export function evaluateDefaultFieldShowed({ defaultValue, parsedDefaultValue, isMandatory, isShowedFromUser }) {
+  if (isMandatory) {
     return true
   }
-
-  if (isShowedFromUser) {
+  if (!isEmptyValue(defaultValue) || !isEmptyValue(parsedDefaultValue)) {
     return true
   }
-  return false
+  return Boolean(isShowedFromUser)
 }
 
 /**
@@ -198,10 +197,13 @@ export const containerManager = {
   },
 
   isDisplayedField,
-  isDisplayedDefault: ({ isMandatory, defaultValue }) => {
+  isDisplayedDefault: ({ isMandatory, defaultValue, isShowedFromUser }) => {
     // add is showed from user
-    if (isMandatory || !isEmptyValue(defaultValue)) {
+    if (isMandatory) {
       return true
+    }
+    if (!isEmptyValue(defaultValue)) {
+      return isShowedFromUser
     }
     return false
   },

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -224,7 +224,7 @@ export function generateField({
       // if field with value displayed in main panel
       field.isShowedFromUser = evaluateDefaultFieldShowed({
         ...field,
-        defaultValue: parsedDefaultValueTo
+        parsedDefaultValue: parsedDefaultValueTo
       })
     }
   }
@@ -233,7 +233,7 @@ export function generateField({
   if (!typeRange) {
     field.isShowedFromUser = evaluateDefaultFieldShowed({
       ...field,
-      defaultValue: parsedDefaultValue
+      parsedDefaultValue
     })
   }
   field.isShowedFromUserDefault = field.isShowedFromUser


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Financial Report` window.
2. Select `Create Report` button field.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/175982057-59113a5e-039d-4516-a791-cbe82c5eeceb.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/175982086-c9e5ac0e-dc83-476f-9488-92a292e5b4c3.mp4

#### Expected behavior
The `Period` parameter has a value in the window from which the report is opened, so this window value must be set in the process parameter

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.
