### PR TITLE
feat: Refresh records after run process on window.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -189,6 +189,31 @@ export default {
                 containerUuid: process.uuid,
                 tableName,
                 recordUuid
+              }).then(async processResponse => {
+                if (processResponse.isError) {
+                  return
+                }
+
+                // update records
+                await dispatch('getEntities', {
+                  parentUuid,
+                  containerUuid
+                })
+                // update records and logics on child tabs
+                tabDefinition.childTabs.filter(tabItem => {
+                  // get loaded tabs with records
+                  return store.getters.getIsLoadedTabRecord({
+                    containerUuid: tabItem.uuid
+                  })
+                }).forEach(tabItem => {
+                  // if loaded data refresh this data
+                  // TODO: Verify with get one entity, not get all list
+                  store.dispatch('getEntities', {
+                    parentUuid,
+                    containerUuid: tabItem.uuid,
+                    pageNumber: 1 // reload with first page
+                  })
+                })
               })
             },
             beforeOpen: () => {

--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -51,6 +51,7 @@ const windowManager = {
     setTabData(state, {
       parentUuid,
       containerUuid,
+      searchValue = '',
       recordsList = [],
       selectionsList = [],
       nextPageToken,
@@ -62,6 +63,7 @@ const windowManager = {
       const dataTab = {
         parentUuid,
         containerUuid,
+        searchValue,
         recordsList,
         selectionsList,
         nextPageToken,
@@ -125,6 +127,12 @@ const windowManager = {
         }
         const currentPageNumber = pageNumber
         const pageToken = generatePageToken({ pageNumber })
+
+        if (isEmptyValue(searchValue)) {
+          searchValue = getters.getSearchValueTabRecordsList({
+            containerUuid
+          })
+        }
 
         const {
           contextColumnNames, name, linkColumnName,
@@ -254,6 +262,7 @@ const windowManager = {
             commit('setTabData', {
               parentUuid,
               containerUuid,
+              searchValue,
               recordsList: dataToStored,
               nextPageToken: dataResponse.nextPageToken,
               pageNumber: currentPageNumber,
@@ -383,6 +392,7 @@ const windowManager = {
       return state.tabData[containerUuid] || {
         parentUuid: undefined,
         containerUuid,
+        searchValue: '',
         recordsList: [],
         selectionsList: [],
         nextPageToken: undefined,
@@ -396,6 +406,11 @@ const windowManager = {
       return getters.getTabData({
         containerUuid
       }).isLoaded || false
+    },
+    getSearchValueTabRecordsList: (state, getters) => ({ containerUuid }) => {
+      return getters.getTabData({
+        containerUuid
+      }).searchValue || ''
     },
     getTabRecordCount: (state, getters) => ({ containerUuid }) => {
       return getters.getTabData({ containerUuid }).recordCount

--- a/src/views/ADempiere/Process/mixinProcess.js
+++ b/src/views/ADempiere/Process/mixinProcess.js
@@ -20,79 +20,12 @@ import store from '@/store'
 import lang from '@/lang'
 
 // utils and helper methods
-import {
-  isDisplayedField,
-  isMandatoryField,
-  isReadOnlyField
-} from '@/utils/ADempiere/dictionary/process.js'
+import { containerManager } from '@/utils/ADempiere/dictionary/process.js'
 
 export default (processUuid) => {
   const storedProcessDefinition = computed(() => {
     return store.getters.getStoredProcess(processUuid)
   })
-
-  const containerManager = {
-    getPanel({ containerUuid }) {
-      return store.getters.getStoredProcess(containerUuid)
-    },
-    getFieldsList({ containerUuid }) {
-      return store.getters.getStoredFieldsFromProcess(containerUuid)
-    },
-
-    actionPerformed: ({ field, value }) => {
-      // store.dispatch('processActionPerformed', {
-      //   field,
-      //   value
-      // })
-    },
-
-    setDefaultValues: ({ containerUuid }) => {
-      store.dispatch('setProcessDefaultValues', {
-        containerUuid
-      })
-    },
-
-    isDisplayedField,
-
-    isReadOnlyField,
-
-    isMandatoryField,
-
-    changeFieldShowedFromUser({ containerUuid, fieldsShowed }) {
-      store.dispatch('changeProcessFieldShowedFromUser', {
-        containerUuid,
-        fieldsShowed
-      })
-    },
-
-    /**
-     * @returns Promisse with value and displayedValue
-     */
-    getDefaultValue({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName, value }) {
-      return store.dispatch('getDefaultValueFromServer', {
-        parentUuid,
-        containerUuid,
-        contextColumnNames,
-        processParameterUuid: uuid,
-        id,
-        //
-        columnName,
-        value
-      })
-    },
-    getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid, searchValue, isAddBlankValue = false, blankValue }) {
-      return store.dispatch('getLookupListFromServer', {
-        parentUuid,
-        containerUuid,
-        contextColumnNames,
-        processParameterUuid: uuid,
-        searchValue,
-        // app attributes
-        isAddBlankValue,
-        blankValue
-      })
-    }
-  }
 
   const actionsList = computed(() => {
     return store.getters.getStoredActionsMenu({


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `View` window.
2. Create new record.
3. Open `View Copy From` process associated.
4. Select `Contact View` in `View` parameter field.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/176009995-6f559ba9-e348-4cf1-9a0b-171c08fe3ca0.mp4

#### Expected behavior

The records of the tab from which it is executed and its loaded dependent tabs are updated with the new records created by the process.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.
