### PR TITLE
feat: Clear stored data on browser and tab.

### DIFF
--- a/src/layout/components/TagsView/index.vue
+++ b/src/layout/components/TagsView/index.vue
@@ -216,7 +216,6 @@ export default {
           if (panelType === 'window') {
             parentUuid = view.meta.uuid
             containerUuid = view.meta.tabUuid
-            this.$store.dispatch('setWindowOldRoute')
           }
 
           const defaultValuesDispatch = `set${capitalize(panelType)}DefaultValues`
@@ -228,18 +227,22 @@ export default {
               panelType,
               isNewRecord: false
             })
+          } else {
+            this.$store.dispatch('setDefaultValues', {
+              parentUuid,
+              containerUuid,
+              panelType,
+              isNewRecord: false
+            })
           }
 
-          this.$store.dispatch('setDefaultValues', {
-            parentUuid,
-            containerUuid,
-            panelType,
-            isNewRecord: false
-          })
-
-          if (['window', 'browser'].includes(panelType)) {
-            this.$store.dispatch('deleteRecordContainer', {
-              viewUuid: view.meta.uuid
+          if (panelType === 'window') {
+            this.$store.dispatch('clearTabData', {
+              parentUuid
+            })
+          } else if (panelType === 'browser') {
+            this.$store.dispatch('clearBrowserData', {
+              containerUuid
             })
           }
         }

--- a/src/store/modules/ADempiere/browserManager.js
+++ b/src/store/modules/ADempiere/browserManager.js
@@ -322,6 +322,15 @@ const browserControl = {
             reject(error)
           })
       })
+    },
+
+    clearBrowserData({ commit }, {
+      containerUuid
+    }) {
+      // clear data on this browser
+      commit('clearBrowserData', {
+        containerUuid
+      })
     }
   },
 

--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -75,6 +75,10 @@ const windowManager = {
       Vue.set(state.tabData, containerUuid, dataTab)
     },
 
+    clearTabData(state, { containerUuid }) {
+      Vue.set(state.tabData, containerUuid, undefined)
+    },
+
     setTabSelectionsList(state, {
       containerUuid,
       selectionsList
@@ -379,6 +383,27 @@ const windowManager = {
             })
             reject(error)
           })
+      })
+    },
+
+    clearTabData({ commit, rootGetters }, {
+      parentUuid,
+      containerUuid
+    }) {
+      // clear only this tab
+      if (!isEmptyValue(containerUuid)) {
+        commit('clearTabData', {
+          containerUuid
+        })
+        return
+      }
+
+      // clear all tabs
+      const { tabsList } = rootGetters.getStoredWindow(parentUuid)
+      tabsList.forEach(tab => {
+        commit('clearTabData', {
+          containerUuid: tab.uuid
+        })
       })
     }
   },


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any smart browser.
2. Start query.
3. Close current smart browser.
4. Open same smart browser.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/176026435-5d4da313-0848-4944-b030-1d481d56fb35.mp4


After this changes:

https://user-images.githubusercontent.com/20288327/176026428-c29ebeaf-4d87-4aab-8bf4-b39283dbb04a.mp4



#### Expected behavior
When closing a window, the logs of all associated tabs must be cleared, likewise, when closing a smart browser, the consulted logs must be cleared.


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.
