### PR TITLE
fix: Refresh page with enter key.

### DIFF
--- a/src/views/ADempiere/ProcessActivity/modeDesktop.vue
+++ b/src/views/ADempiere/ProcessActivity/modeDesktop.vue
@@ -91,7 +91,12 @@
                 </div>
                 <el-collapse-transition>
                   <div v-show="(currentKey === index)">
-                    <el-form label-position="top" style="padding-left: 1%;" :inline="true">
+                    <el-form
+                      label-position="top"
+                      style="padding-left: 1%;"
+                      :inline="true"
+                      @submit.native.prevent="notSubmitForm"
+                    >
                       <el-form-item :label="$t('table.ProcessActivity.Logs')" style="margin-bottom: 0;">
 
                         <span v-if="activity.isReport && !isEmptyValue(activity.summary)">
@@ -208,7 +213,12 @@
                 </div>
                 <el-collapse-transition>
                   <div v-show="(currentKey === index)">
-                    <el-form label-position="top" style="padding-left: 1%;" :inline="true">
+                    <el-form
+                      label-position="top"
+                      style="padding-left: 1%;"
+                      :inline="true"
+                      @submit.native.prevent="notSubmitForm"
+                    >
                       <el-form-item :label="$t('table.ProcessActivity.Logs')" style="margin-bottom: 0;">
 
                         <span v-if="activity.isReport && !isEmptyValue(activity.summary)">

--- a/src/views/ADempiere/ProcessActivity/modeMobile.vue
+++ b/src/views/ADempiere/ProcessActivity/modeMobile.vue
@@ -72,7 +72,12 @@
                 </div>
                 <el-collapse-transition>
                   <div v-show="(currentKey === index)">
-                    <el-form label-position="top" style="padding-left: 1%;" :inline="true">
+                    <el-form
+                      label-position="top"
+                      style="padding-left: 1%;"
+                      :inline="true"
+                      @submit.native.prevent="notSubmitForm"
+                    >
                       <el-form-item :label="$t('table.ProcessActivity.Logs')" style="margin-bottom: 0;">
 
                         <span v-if="activity.isReport && !isEmptyValue(activity.summary)">

--- a/src/views/ADempiere/Test/index.vue
+++ b/src/views/ADempiere/Test/index.vue
@@ -43,6 +43,7 @@
               <el-form
                 label-position="top"
                 label-width="200px"
+                @submit.native.prevent="notSubmitForm"
               >
                 <el-row>
                   <field


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Business Partner` window.
2. Open `Bank Account` tab.
3. Select `New` button.
4. Fill `Name` field and press `enter` key.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/176481667-2c7214fa-48db-4e54-abde-5e208007ad56.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/176482078-4794c739-56c4-416c-847f-b1e01c82fd7f.mp4


#### Expected behavior

The browser page should not refresh when the enter key is pressed on a field.


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Depends on changes https://github.com/solop-develop/frontend-default-theme/pull/76