### PR TITLE
fix: Delete record with other client.

### DIFF
--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -190,7 +190,17 @@ export const deleteRecord = {
     const tab = store.getters.getStoredTab(parentUuid, containerUuid)
     if (tab.isDeleteable && !tab.isReadOnly) {
       const recordUuid = store.getters.getUuidOfContainer(containerUuid)
-      return !isEmptyValue(recordUuid)
+      if (!isEmptyValue(recordUuid) && recordUuid !== 'create-new') {
+        // client id value of record
+        const clientIdRecord = store.getters.getValueOfField({
+          parentUuid,
+          containerUuid,
+          columnName: CLIENT
+        })
+        // evaluate client id context with record
+        const preferenceClientId = store.getters.getSessionContextClientId
+        return clientIdRecord === preferenceClientId
+      }
     }
 
     return false


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `GardenAdmin`.
2. Open any window with `System` client records.
3. Show `Client` field.
4. Delete record with `System` client.

#### Screenshot or Gif

Before this changes

https://user-images.githubusercontent.com/20288327/176515745-13c4d21a-6eed-4b8d-b748-57bec1fa8896.mp4

After this changes

https://user-images.githubusercontent.com/20288327/176515359-d4126c51-d188-430b-a625-c666dc236fbc.mp4


#### Expected behavior
It should not allow deleting records from another client, in this case it is hidden from the convenience buttons and disabled from the actions menu.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Depends on changes https://github.com/solop-develop/frontend-default-theme/pull/77
