### PR TITLE
feat: New/Undo without server request.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -364,7 +364,7 @@ export default {
    * @param {string}  containerUuid
    * TODO: Evaluate if it is necessary to parse the default values
    */
-  setTabDefaultValues({ commit, dispatch, rootGetters }, {
+  setTabDefaultValues({ commit, dispatch, getters, rootGetters }, {
     parentUuid,
     containerUuid,
     isOverWriteParent = true
@@ -415,6 +415,13 @@ export default {
         })
       }
 
+      const recordUuid = store.getters.getUuidOfContainer(containerUuid)
+      // set old record
+      store.commit('setRecordUuidOnPanel', {
+        containerUuid,
+        recordUuid
+      })
+
       // update fields values
       dispatch('updateValuesOfContainer', {
         parentUuid,
@@ -450,7 +457,30 @@ export default {
         }
       })
 
+      // return values
       resolve(defaultAttributes)
+
+      // update records and logics on child tabs
+      tab.childTabs
+        .filter(tabItem => {
+          // get loaded tabs with records
+          return getters.getIsLoadedTabRecord({
+            containerUuid: tabItem.uuid
+          }) || getters.getIsLoadedTabOldRecord({
+            containerUuid: tabItem.uuid
+          })
+        })
+        .forEach(tabItem => {
+          // if loaded data refresh this data
+          dispatch('setTabDefaultValues', {
+            parentUuid,
+            containerUuid: tabItem.uuid
+          })
+          commit('setNewTabData', {
+            parentUuid,
+            containerUuid: tabItem.uuid
+          })
+        })
     })
   }
 

--- a/src/store/modules/ADempiere/persistence.js
+++ b/src/store/modules/ADempiere/persistence.js
@@ -174,9 +174,6 @@ const persistence = {
   },
 
   getters: {
-    getPersistenceMap: (state) => (tableName) => {
-      return state.persistence[tableName]
-    },
     getPersistenceAttributes: (state) => (containerUuid) => {
       const attributesMap = state.persistence[containerUuid]
       if (!isEmptyValue(attributesMap)) {

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -387,14 +387,20 @@ export function getContextAttributes({
   return contextAttributesList
 }
 
-export function generateContextKey(contextAttributes = []) {
+/**
+ * Get context key based on attributes list
+ * @param {array} contextAttributes
+ * @param {string} keyName, default is 'columnName' or 'key'
+ * @returns {string} '_|key|value'
+ */
+export function generateContextKey(contextAttributes = [], keyName = 'columnName,') {
   let contextKey = ''
   if (isEmptyValue(contextAttributes)) {
     return contextKey
   }
 
-  contextAttributes.map(attribute => {
-    contextKey += '|' + attribute.columnName + '|' + attribute.value
+  contextAttributes.forEach(attribute => {
+    contextKey += '|' + attribute[keyName] + '|' + attribute.value
   })
   return '_' + contextKey
 }


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Business Partner` window.
2. Select `Bank Account` tab.
3. Create a record.
4. Select `New` button in `Business Partner` tab.
5. Select `Undo` button in `Business Partner` tab.


#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/177384921-b1b089cd-fe66-4888-a51a-4800a0e0d031.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/177384952-08492655-b7af-486e-9848-eea7f3044d48.mp4


#### Expected behavior
It is expected that undoing the changes will set the previous record and not request the child tabs to set the records that were there before.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes: https://github.com/solop-develop/frontend-core/issues/245
Depends on changes https://github.com/solop-develop/frontend-default-theme/pull/85

