### PR TITLE
fix: Window read only field.

### DIFF
--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -26,9 +26,10 @@ import {
 
 // utils and helpers methods
 import { convertObjectToKeyValue } from '@/utils/ADempiere/valueFormat'
+import { convertStringToBoolean } from '@/utils/ADempiere/formatValue/booleanFormat'
 import { generatePanelAndFields } from '@/utils/ADempiere/dictionary/panel.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
-import { isHiddenField } from '@/utils/ADempiere/references.js'
+import { BUTTON, isHiddenField } from '@/utils/ADempiere/references.js'
 import { showMessage } from '@/utils/ADempiere/notification.js'
 import { zoomIn } from '@/utils/ADempiere/coreUtils'
 
@@ -811,7 +812,7 @@ export const containerManager = {
       !isEmptyValue(recordUuid)
 
     if (!isWithRecord) {
-      if (field.componentPath === 'FieldButton') {
+      if (field.displayType === BUTTON.id) {
         return true
       }
     } else {
@@ -832,35 +833,39 @@ export const containerManager = {
         return true
       }
 
-      // is active value of record
-      const isActiveRecord = store.getters.getValueOfField({
-        parentUuid,
-        containerUuid,
-        columnName: ACTIVE
-      })
       // record is inactive isReadOnlyFromForm
-      if (!isActiveRecord && field.columnName !== 'IsActive') {
-        return true
+      if (field.columnName !== ACTIVE) {
+        // is active value of record
+        const isActiveRecord = store.getters.getValueOfField({
+          parentUuid,
+          containerUuid,
+          columnName: ACTIVE
+        })
+        if (!isActiveRecord) {
+          return true
+        }
       }
 
-      // is processed value of record
-      const isProcessed = store.getters.getValueOfField({
-        parentUuid,
-        containerUuid,
-        columnName: PROCESSED
-      })
-      if (isProcessed && field.componentPath !== 'FieldButton') {
-        return true
-      }
+      if (field.displayType !== BUTTON.id) {
+        // is processed value of record
+        const isProcessed = store.getters.getValueOfField({
+          parentUuid,
+          containerUuid,
+          columnName: PROCESSED
+        })
+        if (convertStringToBoolean(isProcessed)) {
+          return true
+        }
 
-      // is processing value of record
-      const isProcessing = store.getters.getValueOfField({
-        parentUuid,
-        containerUuid,
-        columnName: PROCESSING
-      })
-      if (isProcessing && field.componentPath !== 'FieldButton') {
-        return true
+        // is processing value of record
+        const isProcessing = store.getters.getValueOfField({
+          parentUuid,
+          containerUuid,
+          columnName: PROCESSING
+        })
+        if (convertStringToBoolean(isProcessing)) {
+          return true
+        }
       }
     }
 

--- a/src/utils/ADempiere/formatValue/booleanFormat.js
+++ b/src/utils/ADempiere/formatValue/booleanFormat.js
@@ -49,6 +49,7 @@ export const convertBooleanToString = (booleanValue, isForce = true) => {
 /**
  * Convert string values ('Y' or 'N') to component compatible Boolean values
  * @param {mixed} valueToParsed
+ * @returns {boolean}
  */
 export const convertStringToBoolean = (valueToParsed) => {
   let valReturn = valueToParsed


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Discount Schema` window.
2. Show `Client`, `Organization`, and `Active` fields.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/177617480-21413d6c-e123-44ce-a7ad-70e8849be4da.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/177617519-dd6c454c-b57e-43eb-8eaa-c69a002c1deb.mp4

#### Expected behavior

Note that the `Name` field is displayed as read-only when it should allow editing, as well as the fields within the `Discount Break` tab.


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fix #223 

