### PR TITLE
fix: Lookup list sales transaction context.

### DIFF
--- a/src/utils/ADempiere/constants/systemColumns.js
+++ b/src/utils/ADempiere/constants/systemColumns.js
@@ -28,6 +28,17 @@ export const UUID = 'UUID'
 
 export const WAREHOUSE = 'M_Warehouse_ID'
 
+export const IS_SALES_TRANSACTION = 'IsSalesTransaction'
+export const IS_SO_TRX = 'IsSOTrx'
+
+/**
+ * Is sales transaction (IsSOTrx, IsSalesTransaction)
+ */
+export const SALES_TRANSACTION_COLUMNS = [
+  IS_SALES_TRANSACTION,
+  IS_SO_TRX
+]
+
 /**
  * Log columns list into table
  * Manages with user session

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -14,10 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import router from '@/router'
 import store from '@/store'
 
 // constants
-import { ACCOUNTING_COLUMNS } from '@/utils/ADempiere/constants/systemColumns.js'
+import { ACCOUNTING_COLUMNS, SALES_TRANSACTION_COLUMNS } from '@/utils/ADempiere/constants/systemColumns.js'
 
 // utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
@@ -62,7 +63,7 @@ export const getContext = ({
     columnName.startsWith(GLOBAL_CONTEXT_PREFIX) ||
     columnName.startsWith(PREFERENCE_CONTEXT_PREFIX)
 
-  // get value to session context
+  // get value by session context
   if (isPreferenceValue) {
     value = store.getters.getSessionContext({
       parentUuid,
@@ -70,14 +71,14 @@ export const getContext = ({
       columnName
     })
   } else {
-    // get value to container view
+    // get value by container view
     value = store.getters.getValueOfField({
       parentUuid,
       containerUuid,
       columnName
     })
 
-    // get to global and accounting context
+    // get by global and accounting context
     if (isForceSession && isEmptyValue(value)) {
       value = store.getters.getSessionContext({
         parentUuid,
@@ -92,6 +93,12 @@ export const getContext = ({
         })
       }
     }
+  }
+
+  // get by menu sales transaction
+  if (isEmptyValue(value) && SALES_TRANSACTION_COLUMNS.includes(columnName)) {
+    const currentRoute = router.app._route
+    value = currentRoute.meta.isSalesTransaction
   }
 
   if (isBooleanToString) {
@@ -303,7 +310,7 @@ export function parseContext({
     }
 
     // menu attribute isEmptyValue isSOTrx
-    if (!isEmptyValue(isSOTrxMenu) && token === 'IsSOTrx' && isEmptyValue(contextInfo)) {
+    if (!isEmptyValue(isSOTrxMenu) && isEmptyValue(contextInfo) && SALES_TRANSACTION_COLUMNS.includes(token)) {
       contextInfo = isSOTrxMenu
     }
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Discount Schema` window.
2. Expand list of `Discount Type` field.


#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/177623288-ad61ea89-4aea-4cab-94e8-5a35e04d2ac8.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/177623319-55cc00ff-2421-4d3e-8bc0-004323caff79.mp4


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Addtional context

In the list of context columns there is the column `IsSOTrx` which does not exist in the list of fields and was sent without value, however this attribute can be obtained from the menu

http://localhost:8085/api/adempiere/user-interface/window/lookup-items?context_attributes[]=%7B%22key%22:%22IsSOTrx%22%7D&field_uuid=8ce87044-fb40-11e8-a479-7a0060f0aa01&search_value=&column_name=DiscountType&token=c448225f-2098-484c-b592-12446275f70b&language=en

