### PR TITLE
feat: Replace includes to startsWith and endsWith.

### DIFF
--- a/src/store/modules/ADempiere/browserManager.js
+++ b/src/store/modules/ADempiere/browserManager.js
@@ -22,6 +22,7 @@ import { requestBrowserSearch, updateBrowserEntity, requestDeleteBrowser } from 
 
 // constants
 import { ROW_ATTRIBUTES, ROW_KEY_ATTRIBUTES } from '@/utils/ADempiere/constants/table'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
@@ -451,7 +452,7 @@ const browserControl = {
         const attributesList = []
 
         Object.keys(itemRow).forEach(columnName => {
-          if (!columnName.includes('DisplayColumn') && !ROW_KEY_ATTRIBUTES.includes(columnName)) {
+          if (!columnName.startsWith(DISPLAY_COLUMN_PREFIX) && !ROW_KEY_ATTRIBUTES.includes(columnName)) {
             // evaluate metadata attributes before to convert
             if (fieldsListSelection.includes(columnName)) {
               attributesList.push({

--- a/src/store/modules/ADempiere/data/getters.js
+++ b/src/store/modules/ADempiere/data/getters.js
@@ -1,3 +1,18 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 // constants
 import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'

--- a/src/store/modules/ADempiere/data/getters.js
+++ b/src/store/modules/ADempiere/data/getters.js
@@ -1,4 +1,8 @@
 
+// constants
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
+
+// utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 
 const getters = {
@@ -66,7 +70,7 @@ const getters = {
       const records = []
 
       Object.keys(itemRow).forEach(key => {
-        if (!key.includes('DisplayColumn') && !withOut.includes(key)) {
+        if (!key.startsWith(DISPLAY_COLUMN_PREFIX) && !withOut.includes(key)) {
           // evaluate metadata attributes before to convert
           if (fieldsListSelection.includes(key)) {
             records.push({

--- a/src/store/modules/ADempiere/data/mutations.js
+++ b/src/store/modules/ADempiere/data/mutations.js
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+// constants
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
+
 const mutations = {
 
   deleteRecordContainer(state, payload) {
@@ -22,7 +25,7 @@ const mutations = {
   notifyCellTableChange: (state, payload) => {
     payload.row[payload.columnName] = payload.value
     if (payload.displayColumnName !== undefined) {
-      const key = `DisplayColumn_${payload.columnName}`
+      const key = DISPLAY_COLUMN_PREFIX + payload.columnName
       payload.row[key] = payload.displayColumnName
     }
   },
@@ -30,7 +33,7 @@ const mutations = {
     if (payload.row !== undefined) {
       payload.row[payload.columnName] = payload.value
       if (payload.displayColumnName !== undefined) {
-        const key = `DisplayColumn_${payload.columnName}`
+        const key = DISPLAY_COLUMN_PREFIX + payload.columnName
         payload.row[key] = payload.displayColumnName
       }
     }

--- a/src/store/modules/ADempiere/dictionary/browser/actions.js
+++ b/src/store/modules/ADempiere/dictionary/browser/actions.js
@@ -26,6 +26,7 @@ import {
   exportRecordsSelected,
   sharedLink
 } from '@/utils/ADempiere/constants/actionsMenuList'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
@@ -68,8 +69,8 @@ export default {
             browserDefinition.elementsList[fieldItem.columnName] = fieldItem.elementName
             browserDefinition.columnsList[fieldItem.elementName] = fieldItem.columnName
             if (isLookup(fieldItem.displayType)) {
-              browserDefinition.elementsList[`DisplayColumn_` + fieldItem.columnName] = `DisplayColumn_` + fieldItem.elementName
-              browserDefinition.columnsList[`DisplayColumn_` + fieldItem.elementName] = `DisplayColumn_` + fieldItem.columnName
+              browserDefinition.elementsList[DISPLAY_COLUMN_PREFIX + fieldItem.columnName] = DISPLAY_COLUMN_PREFIX + fieldItem.elementName
+              browserDefinition.columnsList[DISPLAY_COLUMN_PREFIX + fieldItem.elementName] = DISPLAY_COLUMN_PREFIX + fieldItem.columnName
             }
 
             if (fieldItem.isRange) {

--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -433,7 +433,7 @@ export default {
       })
 
       defaultAttributes.forEach(attribute => {
-        if (!attribute.columnName.includes(DISPLAY_COLUMN_PREFIX)) {
+        if (!attribute.columnName.startsWith(DISPLAY_COLUMN_PREFIX)) {
           if (!isEmptyValue(attribute.value)) {
             commit('addChangeToPersistenceQueue', {
               ...attribute,

--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -198,7 +198,7 @@ export default {
     let attributesList = fieldsList
       .map(fieldItem => {
         const { uuid, columnName, defaultValue, contextColumnNames } = fieldItem
-        const isSQL = String(defaultValue).includes('@SQL=') && isGetServer
+        const isSQL = String(defaultValue).startsWith('@SQL=') && isGetServer
         const isLinkColumn = !isEmptyValue(linkColumnName) && columnName === linkColumnName
         const isParentColumn = fieldItem.isParent || (!isEmptyValue(parentColumnName) && columnName === parentColumnName)
 

--- a/src/store/modules/ADempiere/panel/actions.js
+++ b/src/store/modules/ADempiere/panel/actions.js
@@ -479,7 +479,7 @@ const actions = {
       // default value without sql
       if (!isEmptyValue(fieldDependent.defaultValue) &&
         fieldDependent.defaultValue.includes('@') &&
-        !fieldDependent.defaultValue.includes('@SQL=')) {
+        !fieldDependent.defaultValue.startsWith('@SQL=')) {
         defaultValue = parseContext({
           parentUuid,
           containerUuid,
@@ -489,7 +489,7 @@ const actions = {
 
       // default value with sql
       if (!isEmptyValue(fieldDependent.defaultValue) &&
-        fieldDependent.defaultValue.includes('@SQL=')) {
+        fieldDependent.defaultValue.startsWith('@SQL=')) {
         defaultValue = parseContext({
           parentUuid,
           containerUuid,

--- a/src/store/modules/ADempiere/panel/getters.js
+++ b/src/store/modules/ADempiere/panel/getters.js
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+// constants
+import { OPERATORS_IGNORE_VALUE } from '@/utils/ADempiere/dataUtils'
+
+// utils and helper methods
 import {
   isEmptyValue,
   parsedValueComponent
@@ -295,7 +299,7 @@ const getters = {
     let attributesList = fieldsList
       .map(fieldItem => {
         const { id, uuid, columnName, defaultValue, contextColumnNames } = fieldItem
-        const isSQL = String(defaultValue).includes('@SQL=') && isGetServer
+        const isSQL = String(defaultValue).startsWith('@SQL=') && isGetServer
 
         let parsedDefaultValue
         if (!isSQL) {
@@ -310,7 +314,7 @@ const getters = {
 
         if (fieldItem.isRange && fieldItem.componentPath !== 'FieldNumber') {
           const { columnNameTo, elementNameTo, defaultValueTo } = fieldItem
-          const isSQLTo = String(defaultValueTo).includes('@SQL=') && isGetServer
+          const isSQLTo = String(defaultValueTo).startsWith('@SQL=') && isGetServer
 
           let parsedDefaultValueTo
           if (!isSQLTo) {
@@ -525,7 +529,7 @@ const getters = {
             })
           }
           if (!isEmptyValue(value) || !isEmptyValue(valueTo) || (fieldItem.isAdvancedQuery &&
-            ['NULL', 'NOT_NULL'].includes(fieldItem.operator))) {
+            OPERATORS_IGNORE_VALUE.includes(fieldItem.operator))) {
             return true
           }
         }
@@ -551,7 +555,8 @@ const getters = {
         }
 
         let values = []
-        if (parameterItem.isAdvancedQuery && ['IN', 'NOT_IN'].includes(parameterItem.operator)) {
+        if (parameterItem.isAdvancedQuery &&
+          OPERATORS_IGNORE_VALUE.includes(parameterItem.operator)) {
           if (Array.isArray(value)) {
             values = value.map(itemValue => {
               const isMandatory = !parameterItem.isAdvancedQuery &&

--- a/src/store/modules/ADempiere/processControl.js
+++ b/src/store/modules/ADempiere/processControl.js
@@ -4,6 +4,7 @@ import {
 
 // constants
 import { REPORT_VIEWER_NAME } from '@/utils/ADempiere/constants/report'
+import { viewerSupportedFormats } from '@/utils/ADempiere/dictionary/report'
 
 import { showNotification } from '@/utils/ADempiere/notification'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
@@ -434,7 +435,7 @@ export default {
               link.href = window.URL.createObjectURL(blob)
               link.download = output.fileName
               // download report file
-              if (!['pdf', 'html'].includes(reportType)) {
+              if (!viewerSupportedFormats.includes(reportType)) {
                 link.click()
               }
               const contextMenuMetadata = rootGetters.getContextMenu(processResult.processUuid)

--- a/src/store/modules/ADempiere/processControl.js
+++ b/src/store/modules/ADempiere/processControl.js
@@ -1,3 +1,19 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import {
   requestRunProcess
 } from '@/api/ADempiere/process'

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -377,13 +377,18 @@ export function getContextAttributes({
   }
 
   contextColumnNames.forEach(columnName => {
-    const value = getContext({
+    let value = getContext({
       parentUuid,
       containerUuid,
       columnName,
       isBooleanToString,
       isForceBoolean
     })
+
+    // if identifier and empty, send value in zero
+    if (isEmptyValue(value) && (columnName.endsWith('_ID') || columnName.endsWith('_ID_To'))) {
+      value = 0
+    }
 
     contextAttributesList.push({
       value,

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -50,7 +50,7 @@ export function isDisplayedField({ isDisplayed, displayLogic, isDisplayedFromLog
  * Default showed field from user
  */
 export function evaluateDefaultFieldShowed({ defaultValue, isMandatory, isShowedFromUser, isParent }) {
-  if (String(defaultValue).includes('@SQL=')) {
+  if (String(defaultValue).startsWith('@SQL=')) {
     return true
   }
 

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -125,7 +125,7 @@ export function generateField({
       isSOTrxMenu
     })
 
-    if (String(fieldToGenerate.defaultValue).includes('@SQL=')) {
+    if (String(fieldToGenerate.defaultValue).startsWith('@SQL=')) {
       // isShowedFromUser = true
       isGetServerValue = true
     }
@@ -144,7 +144,7 @@ export function generateField({
         isSOTrxMenu
       })
 
-      if (String(fieldToGenerate.defaultValueTo).includes('@SQL=')) {
+      if (String(fieldToGenerate.defaultValueTo).startsWith('@SQL=')) {
         isGetServerValue = true
       }
     }

--- a/src/utils/ADempiere/evaluator.js
+++ b/src/utils/ADempiere/evaluator.js
@@ -211,10 +211,10 @@ export class evaluator {
     }
 
     // Handling of ID compare (null => 0)
-    if (first.includes('_ID') && isEmptyValue(firstEval)) {
+    if (first.endsWith('_ID') && isEmptyValue(firstEval)) {
       firstEval = '0'
     }
-    if (second.includes('_ID') && isEmptyValue(secondEval)) {
+    if (second.endsWith('_ID') && isEmptyValue(secondEval)) {
       secondEval = '0'
     }
 

--- a/src/utils/ADempiere/lookupFactory.js
+++ b/src/utils/ADempiere/lookupFactory.js
@@ -67,7 +67,7 @@ import store from '@/store'
 
 // constants
 import { CHAR, DEFAULT_SIZE, TABLE_DIRECT } from '@/utils/ADempiere/references.js'
-import { evalutateTypeField, getDefaultValue, getEvaluatedLogics } from '@/utils/ADempiere/dictionaryUtils.js'
+import { DISPLAY_COLUMN_PREFIX, evalutateTypeField, getDefaultValue, getEvaluatedLogics } from '@/utils/ADempiere/dictionaryUtils.js'
 
 // utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
@@ -266,7 +266,7 @@ export function getFieldTemplate(overwriteDefinition) {
     description: '',
     help: '',
     columnName: '',
-    displayColumnName: `DisplayColumn_${overwriteDefinition.columnName}`, // key to display column
+    displayColumnName: DISPLAY_COLUMN_PREFIX + overwriteDefinition.columnName, // key to display column
     fieldGroup: {
       name: '',
       fieldGroupType: ''

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -356,7 +356,7 @@ export function parsedValueComponent({
         value = convertBooleanToString(value)
       }
       // Table (18) or Table Direct (19)
-      if (TABLE_DIRECT.id === displayType || TABLE.id === displayType && columnName.includes('_ID')) {
+      if (TABLE_DIRECT.id === displayType || TABLE.id === displayType && columnName.endsWith('_ID')) {
         if (!isEmptyValue(value)) {
           value = Number(value)
         }


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

Improve performance by replacing the `includes` string function with the `startsWith` and `endsWith` functions as appropriate

Executions per second of the `includes` function (24,906,181) vs the `startsWith` function (32,053,102):

![Screenshot_20220708_203710](https://user-images.githubusercontent.com/20288327/178084980-db5f364c-19fe-4d42-bf31-32f10fa20b54.png)

Executions per second of the `includes` function (15,123,305) vs the `endsWith` function (17,257,294)

![Screenshot_20220708_203733](https://user-images.githubusercontent.com/20288327/178084977-1669e8a3-d11e-4798-8256-eb4c570e9ccf.png)

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Depends on https://github.com/solop-develop/frontend-default-theme/pull/94

See results:
https://www.measurethat.net/Benchmarks/Show/5418/0/endswith-vs-includes

https://www.measurethat.net/Benchmarks/Show/9395/0/startswith-vs-includes

