### PR TITLE
fix: Clear old values after save/undo.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -432,8 +432,13 @@ export default {
         root: true
       })
 
+      // clear old values
+      dispatch('clearPersistence', {
+        containerUuid
+      })
+
       defaultAttributes.forEach(attribute => {
-        if (!attribute.columnName.includes(DISPLAY_COLUMN_PREFIX)) {
+        if (!attribute.columnName.startsWith(DISPLAY_COLUMN_PREFIX)) {
           if (!isEmptyValue(attribute.value)) {
             commit('addChangeToPersistenceQueue', {
               ...attribute,

--- a/src/store/modules/ADempiere/persistence.js
+++ b/src/store/modules/ADempiere/persistence.js
@@ -56,6 +56,12 @@ const persistence = {
         // valueType,
         value
       })
+    },
+    // clear old values
+    clearPersistence(state, {
+      containerUuid
+    }) {
+      state.persistence[containerUuid] = new Map()
     }
   },
 
@@ -137,6 +143,11 @@ const persistence = {
                   type: 'success'
                 })
                 resolve(response)
+
+                // clear old values
+                commit('clearPersistence', {
+                  containerUuid
+                })
               })
               .catch(error => reject(error))
           } else {
@@ -165,6 +176,11 @@ const persistence = {
                 })
 
                 resolve(response)
+
+                // clear old values
+                commit('clearPersistence', {
+                  containerUuid
+                })
               })
               .catch(error => reject(error))
           }

--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -419,6 +419,12 @@ const windowManager = {
             })
 
             resolve(responseDeleteEntity)
+
+            // clear old values
+            dispatch('clearPersistenceQueue', {
+              containerUuid,
+              recordUuid
+            })
           })
           .catch(error => {
             reject(error)

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -180,6 +180,14 @@ export const undoChange = {
       attributes
     })
 
+    // clear old values
+    store.dispatch('clearPersistenceQueue', {
+      containerUuid,
+      recordUuid: row[UUID]
+    }, {
+      root: true
+    })
+
     const tab = store.getters.getStoredTab(parentUuid, containerUuid)
     // update records and logics on child tabs
     tab.childTabs.filter(tabItem => {
@@ -209,6 +217,14 @@ export const undoChange = {
         parentUuid,
         containerUuid: tabItem.uuid,
         attributes
+      })
+
+      // clear old values
+      store.dispatch('clearPersistenceQueue', {
+        containerUuid,
+        recordUuid: row[UUID]
+      }, {
+        root: true
       })
     })
   }

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -50,7 +50,7 @@ export function isDisplayedField({ isDisplayed, displayLogic, isDisplayedFromLog
  * Default showed field from user
  */
 export function evaluateDefaultFieldShowed({ defaultValue, isMandatory, isShowedFromUser, isParent }) {
-  if (String(defaultValue).includes('@SQL=')) {
+  if (String(defaultValue).startsWith('@SQL=')) {
     return true
   }
 
@@ -738,6 +738,11 @@ export const containerManager = {
       containerUuid,
       attributes,
       isOverWriteParent: tabDefinition.isParentTab
+    })
+
+    // clear old values
+    store.dispatch('clearPersistence', {
+      containerUuid
     })
 
     // active logics with set records values


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window.
2. Change a value.
3. Save changes

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/178115764-9179a15e-c8ae-4205-834e-0364d0bdccf2.mp4

#### Expected behavior
If the value was changed and then changed back to the original value, the undo and save button should disappear

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Depends on https://github.com/solop-develop/frontend-default-theme/pull/95
Fixes https://github.com/solop-develop/frontend-core/issues/231