### PR TITLE
fix: Tabs parent with same size.

### DIFF
--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -530,7 +530,9 @@ export function generateWindow(responseWindow) {
     isShowedTabsParent: true,
     isShowedTabsChildren: true,
     isShowedRecordNavigation: undefined, // TODO: @deprecated
-    isShowedAdvancedQuery: false
+    isShowedAdvancedQuery: false,
+    isFullScreenTabsParent: false,
+    isFullScreenTabsChildren: false
   }
 
   // delete unused property
@@ -596,9 +598,6 @@ export function generateTabs({
       // app properties
       isShowedRecordNavigation: !(currentTab.isSingleRow || isParentTab), // TODO: @deprecated
       isShowedTableRecords: !(currentTab.isSingleRow || isParentTab),
-      isTableViewFullScreen: false,
-      isTabChildFullScreen: false,
-      isViewFullScreen: false,
       index // this index is not related to the index in which the tabs are displayed
     }
 

--- a/src/views/ADempiere/Window/MultiTabWindow.vue
+++ b/src/views/ADempiere/Window/MultiTabWindow.vue
@@ -41,7 +41,7 @@
         :container-uuid="processUuid"
       />
       <tab-manager-child
-        v-if="((isWithChildsTab && isMobile) || getTab.isTableViewFullScreen)"
+        v-if="isWithChildsTab && isMobile"
         :parent-uuid="windowMetadata.uuid"
         :container-manager="containerManager"
         :tabs-list="windowMetadata.tabsListChild"
@@ -50,9 +50,8 @@
         :actions-manager="actionsManager"
       />
     </el-main>
-    <el-footer v-if="!isMobile && !getTab.isTableViewFullScreen" id="footerWindow" :style="styleFullScreen">
+    <el-footer v-if="isWithChildsTab && !isMobile" id="footerWindow" :style="styleFullScreen">
       <tab-manager-child
-        v-if="isWithChildsTab"
         class="tab-manager"
         :parent-uuid="windowMetadata.uuid"
         :container-manager="containerManager"
@@ -132,28 +131,15 @@ export default defineComponent({
       return store.getters.getCurrentTab(props.windowMetadata.uuid).uuid
     })
 
-    const currentTabChild = computed(() => {
-      if (!isEmptyValue(currentTab.value.childTabs) && !isEmptyValue(root.$route.query.tabChild)) {
-        const index = parseInt(root.$route.query.tabChild, 10)
-        return store.getters.getStoredTab(
-          props.windowMetadata.uuid,
-          props.windowMetadata.tabsListChild[index].uuid
-        )
-      }
-      return {}
-    })
-
-    const currentTab = computed(() => {
-      return store.getters.getCurrentTab(props.windowMetadata.uuid)
-    })
-
     const styleFullScreen = computed(() => {
-      if (isEmptyValue(currentTab.value.childTabs)) {
+      if (!isWithChildsTab.value) {
         return 'height: 0% !important'
-      } else if (!isEmptyValue(currentTab.value.childTabs) && currentTab.value.isTableViewFullScreen) {
-        return 'height: 20% !important'
-      } else if (!isEmptyValue(currentTab.value.childTabs) && !currentTab.value.isTableViewFullScreen && !isEmptyValue(currentTabChild.value) && currentTabChild.value.isTabChildFullScreen) {
-        return 'height: 75% !important'
+      } else {
+        if (props.windowMetadata.isFullScreenTabsParent) {
+          return 'height: 20% !important'
+        } else if (props.windowMetadata.isFullScreenTabsChildren) {
+          return 'height: 75% !important'
+        }
       }
 
       return 'height: 50% !important'
@@ -177,10 +163,6 @@ export default defineComponent({
       }
     })
 
-    const getTab = computed(() => {
-      return store.getters.getCurrentTab(props.windowMetadata.uuid)
-    })
-
     const referencesManager = ref({
       getTableName: () => {
         const tabUuid = currentTabUuid.value
@@ -202,10 +184,7 @@ export default defineComponent({
       isWithChildsTab,
       containerManager,
       isMobile,
-      getTab,
-      styleFullScreen,
-      currentTabChild,
-      currentTab
+      styleFullScreen
     }
   }
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature


#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/178404704-769dee3c-0a7d-4c85-a07a-f06adc829645.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/178404708-baca4353-bc83-4ce9-9fef-c157d884412c.mp4



#### Expected behavior
if a parent tab is expanded all other tabs of the same level should be expanded

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Depends on https://github.com/solop-develop/frontend-default-theme/pull/103
fixes: https://github.com/solop-develop/frontend-core/pull/250
