### PR TITLE
feat: Refresh current entity.

### DIFF
--- a/src/api/ADempiere/user-interface/persistence.js
+++ b/src/api/ADempiere/user-interface/persistence.js
@@ -22,6 +22,33 @@ import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 import { ROWS_OF_RECORDS_BY_PAGE } from '@/utils/ADempiere/constants/table'
 
 /**
+ * Get entity from tab uuid and record id or record uuid
+ * @param {string} tabUuid
+ * @param {number}  recordId
+ * @param {string}  recordUuid
+ */
+export function getEntity({
+  tabUuid,
+  recordId,
+  recordUuid
+}) {
+  return request({
+    url: '/user-interface/window/entity',
+    method: 'get',
+    params: {
+      tab_uuid: tabUuid,
+      uuid: recordUuid,
+      id: recordId
+    }
+  })
+    .then(entityResponse => {
+      const { convertEntity } = require('@/utils/ADempiere/apiConverts/persistence.js')
+
+      return convertEntity(entityResponse)
+    })
+}
+
+/**
  * Object List from window
  * @param {string} windowUuid
  * @param {string} tabUuid

--- a/src/lang/ADempiere/en/actionMenu.js
+++ b/src/lang/ADempiere/en/actionMenu.js
@@ -16,6 +16,7 @@
 
 const actionMenu = {
   // actions
+  refresh: 'Refresh',
   refreshRecords: 'Refresh Records',
   deleteRecord: 'Delete Record',
   new: 'New',

--- a/src/lang/ADempiere/es/actionMenu.js
+++ b/src/lang/ADempiere/es/actionMenu.js
@@ -16,6 +16,7 @@
 
 const actionMenu = {
   // actions
+  refresh: 'Refrescar',
   refreshRecords: 'Refrescar Registros',
   deleteRecord: 'Eliminar Registro',
   new: 'Nuevo',

--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -142,7 +142,7 @@ const windowManager = {
       //     }
       //     return currentRow
       //   })
-      const index = recordsList.map(currentRow => {
+      const index = recordsList.findIndex(currentRow => {
         return currentRow[UUID] === recordUuid
       })
 
@@ -585,16 +585,8 @@ const windowManager = {
     },
     getTabCurrentRecord: (state, getters) => ({ containerUuid }) => {
       const recordUuid = getters.getUuidOfContainer(containerUuid)
-      const list = getters.getTabData({ containerUuid }).recordsList
-      let record = []
-      if (!isEmptyValue(recordUuid) && !isEmptyValue(list)) {
-        record = list.find(row => {
-          if (row.UUID === recordUuid) {
-            return row
-          }
-        })
-      }
-      return record
+
+      return getters.getTabRowData({ recordUuid })
     },
     getTabPageNumber: (state, getters) => ({ containerUuid }) => {
       return getters.getTabData({ containerUuid }).pageNumber
@@ -604,6 +596,10 @@ const windowManager = {
     },
     getTabRowData: (state, getters) => ({ containerUuid, recordUuid, rowIndex }) => {
       const recordsList = getters.getTabRecordsList({ containerUuid })
+      if (isEmptyValue(recordsList)) {
+        return {}
+      }
+
       if (!isEmptyValue(rowIndex)) {
         return recordsList[rowIndex]
       }
@@ -613,6 +609,8 @@ const windowManager = {
           return itemData.UUID === recordUuid
         })
       }
+
+      return {}
     },
     getTabCellData: (state, getters) => ({ containerUuid, recordUuid, rowIndex, columnName }) => {
       const recordsList = getters.getTabRecordsList({ containerUuid })


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window.
2. Create new record.
3. Show multi record.
4. Refresh record.

When creating a record, no display values are returned, however when updating the entity, it refreshes only the current record and sets the display values, without updating the entire list of records.

#### Screenshot or Gif


https://user-images.githubusercontent.com/20288327/178754514-6ec6b8c0-6a70-414e-a342-dbe194f6ef24.mp4


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Depends on https://github.com/solop-develop/backend/pull/34
Depends on https://github.com/solop-develop/gRPC-API/pull/6
Depends on https://github.com/solop-develop/proxy-adempiere-api/pull/7
Depends on https://github.com/solop-develop/frontend-default-theme/pull/104