### PR TITLE
fix: ReadOnly logic with call same field.

### DIFF
--- a/src/store/modules/ADempiere/panel/actions.js
+++ b/src/store/modules/ADempiere/panel/actions.js
@@ -397,16 +397,17 @@ const actions = {
               attributes: response.attributes
             })
           }
-
+        })
+        .catch(error => {
+          console.warn(`${field.name} ActionPerformed error: ${error.message}.`)
+        })
+        .finally(() => {
           // Change Dependents
           dispatch('changeDependentFieldsList', {
             field,
             fieldsList,
             containerManager
           })
-        })
-        .catch(error => {
-          console.warn(`${field.panelType}ActionPerformed error: ${error.message}.`)
         })
     })
   },

--- a/src/store/modules/ADempiere/persistence.js
+++ b/src/store/modules/ADempiere/persistence.js
@@ -142,6 +142,7 @@ const persistence = {
             message: language.t('notifications.mandatoryFieldMissing') + emptyFields,
             type: 'info'
           })
+          resolve()
           return
         }
 
@@ -161,6 +162,8 @@ const persistence = {
               resolve(response)
             })
             .catch(error => reject(error))
+        } else {
+          resolve()
         }
       })
     },

--- a/src/utils/ADempiere/dictionary/panel.js
+++ b/src/utils/ADempiere/dictionary/panel.js
@@ -272,8 +272,7 @@ export function generateDependenFieldsList(fieldsList) {
 
     itemField.parentFieldsList.forEach(parentColumnName => {
       const parentField = listFields.find(parentFieldItem => {
-        return parentColumnName !== itemField.columnName &&
-          (parentColumnName === parentFieldItem.columnName ||
+        return (parentColumnName === parentFieldItem.columnName ||
           parentColumnName === parentFieldItem.elementName)
       })
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

A. Window as `Query` window type.
1. Login with `GardenAdmin`
2. Open `Account Combination` window.
3. Show all fields.

Note how the `Is Active` field allows the value to be changed, it should be disabled.

Before this changes:

https://user-images.githubusercontent.com/20288327/179030630-02cedc5c-47a5-483a-840b-c9dc7ee223fe.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/179030666-9a9485d5-d924-4540-9c99-52d79284994d.mp4


B. Field with read-only logic of its own column.
1. Login with `System`
2. Open `Element` window.
3. Show all fields.
4. Select a record with the entity type other than Dictionary.
5. Set the entity type to dictionary

You should set the field to read-only since it calls itself in the read-only logic `@EntityType@=D`.


Before this changes:

https://user-images.githubusercontent.com/20288327/179031528-0c3aea88-b0ac-4864-b346-53d1c5c3c5c8.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/179031625-590c68c5-7e9a-4a59-954f-ec23bc75aed5.mp4



#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes: https://github.com/solop-develop/frontend-core/issues/223
fixes: https://github.com/solop-develop/frontend-core/issues/260
Depends on https://github.com/solop-develop/frontend-default-theme/pull/107