### PR TITLE
fix: Undo changes, set correct values.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -433,12 +433,12 @@ export default {
       })
 
       // clear old values
-      // dispatch('clearPersistenceQueue', {
-      //   containerUuid,
-      //   recordUuid
-      // }, {
-      //   root: true
-      // })
+      dispatch('clearPersistenceQueue', {
+        containerUuid,
+        recordUuid
+      }, {
+        root: true
+      })
 
       defaultAttributes.forEach(attribute => {
         if (!attribute.columnName.startsWith(DISPLAY_COLUMN_PREFIX)) {

--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -182,6 +182,7 @@ export default {
     parentUuid,
     containerUuid,
     isGetServer = true,
+    isAddDisplayColumn = true,
     isSOTrxMenu,
     fieldsList = [],
     formatToReturn = 'array'
@@ -229,7 +230,7 @@ export default {
         attributesObject[columnName] = parsedDefaultValue
 
         // add display column to default
-        if (fieldItem.componentPath === 'FieldSelect') {
+        if (isAddDisplayColumn && fieldItem.componentPath === 'FieldSelect') {
           const { displayColumnName } = fieldItem
           let displayedValue
           if (!isEmptyValue(parsedDefaultValue)) {

--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -583,16 +583,18 @@ const windowManager = {
     getTabSelectionsList: (state, getters) => ({ containerUuid }) => {
       return getters.getTabData({ containerUuid }).selectionsList
     },
-    getTabCurrentRecord: (state, getters) => ({ containerUuid }) => {
-      const recordUuid = getters.getUuidOfContainer(containerUuid)
-
-      return getters.getTabRowData({ recordUuid })
-    },
     getTabPageNumber: (state, getters) => ({ containerUuid }) => {
       return getters.getTabData({ containerUuid }).pageNumber
     },
     getTabPageToken: (state, getters) => ({ containerUuid }) => {
       return getters.getTabData({ containerUuid }).nextPageToken
+    },
+    getTabCurrentRow: (state, getters) => ({ containerUuid }) => {
+      // get current record uuid with container uuid
+      const recordUuid = getters.getUuidOfContainer(containerUuid)
+
+      // get row with record uuid
+      return getters.getTabRowData({ containerUuid, recordUuid })
     },
     getTabRowData: (state, getters) => ({ containerUuid, recordUuid, rowIndex }) => {
       const recordsList = getters.getTabRecordsList({ containerUuid })


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window.
2. Set first record.
3. Change record.
4. Change to first record.
5. Change a value of field.
6. Click on `Undo` button.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/179312646-50d2916e-aef7-44f6-822d-252298fcdee4.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/179312652-72b626d8-a0f6-4de9-8a45-a40311d91190.mp4

#### Expected behavior
If there is a change in the current record, just discard the changes and keep the same record, not change to the previously selected record.


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes: https://github.com/solop-develop/frontend-core/issues/247
Depends on https://github.com/solop-develop/frontend-default-theme/pull/109