### PR TITLE
feat: Support on Business Partner search field

### DIFF
--- a/src/api/ADempiere/system-core.js
+++ b/src/api/ADempiere/system-core.js
@@ -17,6 +17,9 @@
 // Get Instance for connection
 import { request } from '@/utils/ADempiere/request'
 
+// constants
+import { ROWS_OF_RECORDS_BY_PAGE } from '@/utils/ADempiere/constants/table'
+
 // Get Organization list from role
 export function requestOrganizationsList({
   roleUuid,
@@ -214,7 +217,7 @@ export function requestListBusinessPartner({
   phone,
   // Query
   // criteria,
-  pageSize,
+  pageSize = ROWS_OF_RECORDS_BY_PAGE,
   pageToken
 }) {
   return request({

--- a/src/lang/ADempiere/en/businessPartner.js
+++ b/src/lang/ADempiere/en/businessPartner.js
@@ -1,0 +1,25 @@
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const businessPartner = {
+  notFound: 'Business partner not found.',
+  emptyBusinessPartner: 'Use the filters to search for a business partner by Code, Name, Email and Phone Number',
+  searchWithEnter: 'Enter a value to search for a Business Partners'
+}
+
+export default businessPartner

--- a/src/lang/ADempiere/en/index.js
+++ b/src/lang/ADempiere/en/index.js
@@ -1,5 +1,23 @@
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import actionMenu from './actionMenu'
+import businessPartner from './businessPartner'
 import extensionFile from './extensionFile'
 import fieldDisplayOptions from './fieldDisplayOptions'
 import fieldOptions from './fieldOptions'
@@ -10,6 +28,7 @@ import window from './window'
 
 export default {
   actionMenu,
+  businessPartner,
   extensionFile,
   fieldDisplayOptions,
   fieldOptions,
@@ -353,10 +372,6 @@ export default {
     newRecord: 'Quick Access to Create New Record',
     listRecords: 'Quick Access to List All Records',
     searchWithEnter: 'Press enter to search for the product by Product Code, Name or UPC.'
-  },
-  businessPartner: {
-    notFound: 'Business partner not found.',
-    emptyBusinessPartner: 'Use the filters to search for a business partner by Code, Name, Email and Phone Number'
   },
   form: {
     pos: {

--- a/src/lang/ADempiere/es/businessPartner.js
+++ b/src/lang/ADempiere/es/businessPartner.js
@@ -1,0 +1,25 @@
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const businessPartner = {
+  notFound: 'Socio de negocio no encontrado.',
+  emptyBusinessPartner: 'Utilice los filtros para realizar la búsqueda de socio de negocio según su Código, Nombre, Email y Teléfono',
+  searchWithEnter: 'Introduzca un valor para buscar Socios de Negocio'
+}
+
+export default businessPartner

--- a/src/lang/ADempiere/es/index.js
+++ b/src/lang/ADempiere/es/index.js
@@ -1,5 +1,23 @@
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import actionMenu from './actionMenu'
+import businessPartner from './businessPartner'
 import extensionFile from './extensionFile'
 import fieldDisplayOptions from './fieldDisplayOptions'
 import fieldOptions from './fieldOptions'
@@ -10,6 +28,7 @@ import window from './window'
 
 export default {
   actionMenu,
+  businessPartner,
   extensionFile,
   fieldDisplayOptions,
   fieldOptions,
@@ -328,10 +347,6 @@ export default {
     newRecord: 'Acceso Rápido para Crear Registro Nuevo',
     listRecords: 'Acceso Rápido para Listar los Registros',
     searchWithEnter: 'Pulse enter para realizar la busqueda del producto segun su Codigo, Nombre o UPC'
-  },
-  businessPartner: {
-    notFound: 'Socio de negocio no encontrado.',
-    emptyBusinessPartner: 'Utilice los filtros para realizar la busqueda de socio de negocio según su Código, Nombre, Email y Teléfono'
   },
   form: {
     pos: {

--- a/src/store/modules/ADempiere/businessPartnerPOS.js
+++ b/src/store/modules/ADempiere/businessPartnerPOS.js
@@ -1,18 +1,20 @@
-// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
-// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
-// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 // api request methods
 import { requestListBusinessPartner } from '@/api/ADempiere/system-core.js'
@@ -20,7 +22,7 @@ import { requestListBusinessPartner } from '@/api/ADempiere/system-core.js'
 // utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { showMessage } from '@/utils/ADempiere/notification.js'
-import { extractPagingToken, generatePageToken } from '@/utils/ADempiere/dataUtils'
+import { generatePageToken } from '@/utils/ADempiere/dataUtils'
 
 const withoutResponse = {
   isLoaded: false,
@@ -77,16 +79,11 @@ const businessPartner = {
         pageToken
       })
         .then(responseBusinessPartnerList => {
-          let token
-          if (isEmptyValue(token) || isEmptyValue(pageToken)) {
-            token = extractPagingToken(responseBusinessPartnerList.nextPageToken)
-          }
-
+          console.log('listBPartnerFromServer', responseBusinessPartnerList)
           commit('setBusinessPartnersList', {
             ...responseBusinessPartnerList,
             isLoaded: true,
             isReload: false,
-            token,
             pageNumber
           })
 

--- a/src/store/modules/ADempiere/form/businessPartner.js
+++ b/src/store/modules/ADempiere/form/businessPartner.js
@@ -1,0 +1,192 @@
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import Vue from 'vue'
+
+// api request methods
+import { requestListBusinessPartner } from '@/api/ADempiere/system-core.js'
+
+// utils and helper methods
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
+import { showMessage } from '@/utils/ADempiere/notification'
+import { generatePageToken } from '@/utils/ADempiere/dataUtils'
+
+const initState = {
+  businessPartnerPopoverList: false,
+  // container uuid: record uuid
+  emtpyBusinessPartnerData: {
+    parentUuid: undefined,
+    containerUuid: undefined,
+    contextKey: '',
+    searchValue: '',
+    currentRecordUuid: undefined,
+    recordsList: [],
+    selectionsList: [],
+    nextPageToken: undefined,
+    recordCount: 0,
+    isLoaded: false,
+    pageNumber: 1
+  },
+  businessPartnerData: {}
+}
+
+const businessPartner = {
+  state: initState,
+
+  mutations: {
+    setBusinessPartnerData(state, {
+      containerUuid,
+      currentRow = {},
+      recordsList = [],
+      nextPageToken,
+      recordCount = 0,
+      isLoaded = true,
+      pageNumber = 1
+    }) {
+      Vue.set(state.businessPartnerData, containerUuid, {
+        containerUuid,
+        currentRow,
+        recordsList,
+        nextPageToken,
+        recordCount,
+        isLoaded,
+        pageNumber
+      })
+    },
+    setBusinessPartnerSelectedRow(state, {
+      containerUuid,
+      currentRow = {}
+    }) {
+      Vue.set(state.businessPartnerData[containerUuid], 'currentRow', currentRow)
+    },
+
+    changePopoverListBusinessPartner(state, isShowed = false) {
+      state.businessPartnerPopoverList = isShowed
+    }
+  },
+
+  actions: {
+    getBusinessPartners({ commit, getters }, {
+      containerUuid,
+      searchValue,
+      value,
+      name,
+      contactName,
+      eMail,
+      postalCode,
+      phone,
+      filters = [],
+      pageNumber
+    }) {
+      return new Promise(resolve => {
+        if (isEmptyValue(pageNumber) || pageNumber < 1) {
+          const storedPage = getters.getBusinessPartnerPageNumber({
+            containerUuid
+          })
+          // refresh with same page
+          pageNumber = storedPage
+        }
+        const pageToken = generatePageToken({ pageNumber })
+
+        requestListBusinessPartner({
+          searchValue,
+          value,
+          name,
+          contactName,
+          eMail,
+          postalCode,
+          phone,
+          // Query
+          filters,
+          pageToken
+        })
+          .then(responseBusinessPartnerList => {
+            const { businessPartnersList: recordsList } = responseBusinessPartnerList
+
+            let currentRow = {}
+            // update current record
+            if (!isEmptyValue(recordsList)) {
+              // set first record
+              currentRow = recordsList.at(0)
+            }
+
+            commit('setBusinessPartnerData', {
+              containerUuid,
+              currentRow,
+              recordsList,
+              nextPageToken: responseBusinessPartnerList.nextPageToken,
+              pageNumber,
+              isLoaded: true,
+              recordCount: responseBusinessPartnerList.recordCount
+            })
+
+            resolve(recordsList)
+          })
+          .catch(error => {
+            console.warn(error)
+            showMessage({
+              type: 'info',
+              message: error.message
+            })
+          })
+      })
+    }
+  },
+  getters: {
+    /**
+     * Used by result in Business Partner List
+     * @param {string} containerUuid
+     */
+    getBusinessPartnerData: (state) => ({ containerUuid }) => {
+      return state.businessPartnerData[containerUuid] || {
+        ...state.emtpyBusinessPartnerData,
+        containerUuid
+      }
+    },
+    getIsLoadedBusinessPartnerRecord: (state, getters) => ({ containerUuid }) => {
+      return getters.getBusinessPartnerData({
+        containerUuid
+      }).isLoaded
+    },
+    getBusinessPartnerRecordsList: (state, getters) => ({ containerUuid }) => {
+      return getters.getBusinessPartnerData({
+        containerUuid
+      }).recordsList
+    },
+    getBusinessPartnerRecordCount: (state, getters) => ({ containerUuid }) => {
+      return getters.getBusinessPartnerData({
+        containerUuid
+      }).recordCount
+    },
+    getBusinessPartnerPageNumber: (state, getters) => ({ containerUuid }) => {
+      return getters.getBusinessPartnerData({
+        containerUuid
+      }).pageNumber
+    },
+    getBusinessPartnerCurrentRow: (state, getters) => ({ containerUuid }) => {
+      return getters.getBusinessPartnerData({
+        containerUuid
+      }).currentRow
+    },
+    getBusinessPartnerPopoverList: (state) => {
+      return state.businessPartnerPopoverList
+    }
+  }
+}
+
+export default businessPartner

--- a/src/store/modules/ADempiere/utils.js
+++ b/src/store/modules/ADempiere/utils.js
@@ -18,7 +18,6 @@ const initStateUtils = {
   updateOrder: false,
   updatePayment: false,
   createBusinessPartner: false,
-  listBusinessPartner: false,
   copyShippingAddress: true,
   step: 0,
   updateCustomer: false,
@@ -106,9 +105,6 @@ export default {
     },
     popoverCreateBusinessPartner(state, createBusinessPartner) {
       state.createBusinessPartner = createBusinessPartner
-    },
-    popoverListBusinessPartner(state, payload) {
-      state.listBusinessPartner = payload
     },
     popoverOverdrawnInvoice(state, payload) {
       state.overdrawnInvoice = payload
@@ -230,9 +226,6 @@ export default {
     changePopover({ commit }, params) {
       commit('popoverCreateBusinessPartner', params)
     },
-    changePopoverListBusinessPartner({ commit }, params) {
-      commit('popoverListBusinessPartner', params)
-    },
     changeShowAddNewAddress({ commit }, params) {
       commit('setShowAddNewAddress', params)
     },
@@ -318,9 +311,6 @@ export default {
     },
     getPopoverCreateBusinessParnet: (state) => {
       return state.createBusinessPartner
-    },
-    getPopoverListBusinessParnet: (state) => {
-      return state.listBusinessPartner
     },
     getCopyShippingAddress: (state) => {
       return state.copyShippingAddress

--- a/src/utils/ADempiere/dictionary/form/businessPartner/businessPartnerList.js
+++ b/src/utils/ADempiere/dictionary/form/businessPartner/businessPartnerList.js
@@ -1,0 +1,20 @@
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export const BUSINESS_PARTNERS_LIST_FORM = 'Business-Partner-List'
+

--- a/src/utils/ADempiere/dictionary/form/index.js
+++ b/src/utils/ADempiere/dictionary/form/index.js
@@ -1,0 +1,104 @@
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import store from '@/store'
+
+import { isHiddenField } from '@/utils/ADempiere/references'
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
+
+export function getLookupList({ parentUuid, containerUuid, uuid }) {
+  return store.dispatch('getLookupListFromServer', {
+    parentUuid,
+    containerUuid,
+    fieldUuid: uuid
+  })
+}
+
+/**
+ * Dispatch to chagne displayed field on panel/table
+ * @param {string} containerUuid
+ * @param {array} fieldsShowed
+ */
+export function changeFieldShowedFromUser({ containerUuid, fieldsShowed = [] }) {
+  // to forms usupported
+}
+
+/**
+ * Is displayed field
+ * @param {number} displayType
+ * @param {boolean} isActive
+ * @param {boolean} isDisplayed
+ * @param {string} displayLogic
+ * @param {boolean} isDisplayedFromLogic
+ * @returns {boolean}
+ */
+export function isDisplayedField({ displayType, isActive, isDisplayed, displayLogic, isDisplayedFromLogic }) {
+  // fields not showed
+  if (isHiddenField(displayType)) {
+    return false
+  }
+
+  // verify if field is active and displayed
+  return isActive && isDisplayed && (isEmptyValue(displayLogic) || isDisplayedFromLogic)
+}
+
+export function isDisplayedDefault({ isMandatory }) {
+  return true
+}
+
+/**
+ * Manager mandatory logic
+ * @param {boolean} isActive
+ * @param {boolean} isMandatory
+ * @param {string} mandatoryLogic
+ * @param {boolean} isMandatoryFromLogic
+ * @returns {boolean}
+ */
+export function isMandatoryField({ isActive, isMandatory, mandatoryLogic, isMandatoryFromLogic }) {
+  // verify if field is active and displayed
+  return isActive && (isMandatory ||
+    (!isEmptyValue(mandatoryLogic) && isMandatoryFromLogic))
+}
+
+/**
+ * Is read only field
+ * @param {boolean} isActive
+ * @param {boolean} isReadOnly
+ * @param {string} readOnlyLogic
+ * @param {boolean} isReadOnlyFromLogic
+ * @returns {boolean}
+ */
+export function isReadOnlyField({ isActive, isReadOnly, readOnlyLogic, isReadOnlyFromLogic }) {
+  return isActive && (isReadOnly ||
+    (!isEmptyValue(readOnlyLogic) && isReadOnlyFromLogic))
+}
+
+export const containerManager = {
+  changeFieldShowedFromUser,
+  isDisplayedField,
+  isDisplayedDefault,
+
+  isMandatoryField,
+
+  isReadOnlyField,
+
+  getLookupList,
+
+  seekRecord({ parentUuid, containerUuid, row }) {
+  }
+}

--- a/src/utils/ADempiere/references.js
+++ b/src/utils/ADempiere/references.js
@@ -246,7 +246,7 @@ export const SEARCH = {
   id: 30,
   isSupported: true,
   valueType: 'INTEGER',
-  componentPath: 'FieldSelect',
+  componentPath: 'FieldSearch',
   size: DEFAULT_SIZE
 }
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Aging` report.
2. Showed `Business Partner` field.
3. Search value with input text and select any record.
4. Click on icon and search values.
5. Select a row and click on the blue ok button to set or if you prefer double click on the row to set the record.


The search by the autocomplete text entry searches only the columns Value, Name, Name2 and Description.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/180309879-5cf8731d-f373-448f-a906-c97d4b4c0767.mp4



#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/273
Depends on https://github.com/solop-develop/frontend-default-theme/pull/116
Depends on https://github.com/solop-develop/backend/pull/37
