### PR TITLE
 fix: Numbers of records selecteds in pagination. 

### DIFF
--- a/src/store/modules/ADempiere/browserManager.js
+++ b/src/store/modules/ADempiere/browserManager.js
@@ -148,7 +148,6 @@ const browserControl = {
             containerUuid
           })
         }
-        const currentPageNumber = pageNumber
         const pageToken = generatePageToken({ pageNumber })
 
         const { fieldsList, contextColumnNames } = rootGetters.getStoredBrowser(containerUuid)
@@ -200,7 +199,7 @@ const browserControl = {
               recordsList,
               recordCount: browserSearchResponse.recordCount,
               nextPageToken: browserSearchResponse.nextPageToken,
-              pageNumber: currentPageNumber,
+              pageNumber,
               isLoaded: true
             })
 

--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -56,13 +56,18 @@ export default {
           parentUuid: windowResponse.uuid,
           containerUuid: tab.uuid
         })
+
+        // dispatch('setTabDefaultValues', {
+        //   parentUuid: windowResponse.uuid,
+        //   containerUuid: tab.uuid
+        // })
       })
 
       resolve(windowResponse)
     })
   },
 
-  getWindowDefinitionFromServer({ dispatch }, {
+  getWindowDefinitionFromServer({ dispatch, rootGetters }, {
     uuid
   }) {
     return new Promise(resolve => {
@@ -74,6 +79,24 @@ export default {
           dispatch('addWindow', window)
 
           resolve(window)
+        })
+        .catch(error => {
+          showMessage({
+            type: 'error',
+            message: error.message
+          })
+
+          // close current page
+          const currentRoute = router.app._route
+          const tabViewsVisited = rootGetters.visitedViews
+          dispatch('tagsView/delView', currentRoute)
+          // go to back page
+          const oldRouter = tabViewsVisited[tabViewsVisited.length - 1]
+          if (!isEmptyValue(oldRouter)) {
+            router.push({
+              path: oldRouter.path
+            }, () => {})
+          }
         })
     })
   },
@@ -417,10 +440,12 @@ export default {
 
       const recordUuid = store.getters.getUuidOfContainer(containerUuid)
       // set old record
-      store.commit('setRecordUuidOnPanel', {
-        containerUuid,
-        recordUuid
-      })
+      if (!isEmptyValue(recordUuid)) {
+        store.commit('setRecordUuidOnPanel', {
+          containerUuid,
+          recordUuid
+        })
+      }
 
       // update fields values
       dispatch('updateValuesOfContainer', {

--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -213,14 +213,12 @@ const windowManager = {
           // refresh with same page
           pageNumber = storedPage
         }
+        const pageToken = generatePageToken({ pageNumber })
 
         if (!isEmptyValue(filters)) {
           const parseFilter = JSON.parse(filters)
           filters = [parseFilter]
         }
-
-        const currentPageNumber = pageNumber
-        const pageToken = generatePageToken({ pageNumber })
 
         if (isEmptyValue(searchValue)) {
           searchValue = getters.getSearchValueTabRecordsList({
@@ -370,7 +368,7 @@ const windowManager = {
               currentRecordUuid,
               recordsList: dataToStored,
               nextPageToken: dataResponse.nextPageToken,
-              pageNumber: currentPageNumber,
+              pageNumber,
               isLoaded: true,
               recordCount: dataResponse.recordCount
             })


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open a search field `Business Partner`.
2. Show table list.

#### Screenshot or Gif

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/180451915-62da8e98-3c9e-4df2-b380-697f80d922ed.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/180452703-b42c700c-ebd9-42cd-b5c2-bf90703a7ebf.mp4


#### Expected behavior
If the selection is not defined, it should not show the values related to the selection.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes: https://github.com/solop-develop/frontend-core/issues/268
Depends on https://github.com/solop-develop/frontend-default-theme/pull/117
