### PR TITLE
fix: Business Partner Info displayed value.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -466,16 +466,16 @@ export default {
       })
 
       defaultAttributes.forEach(attribute => {
-        if (!attribute.columnName.startsWith(DISPLAY_COLUMN_PREFIX)) {
-          if (!isEmptyValue(attribute.value)) {
-            commit('addChangeToPersistenceQueue', {
-              ...attribute,
-              containerUuid
-            }, {
-              root: true
-            })
-          }
+        if (!isEmptyValue(attribute.value)) {
+          commit('addChangeToPersistenceQueue', {
+            ...attribute,
+            containerUuid
+          }, {
+            root: true
+          })
+        }
 
+        if (!attribute.columnName.startsWith(DISPLAY_COLUMN_PREFIX)) {
           const field = rootGetters.getStoredFieldFromTab({
             windowUuid: parentUuid,
             tabUuid: containerUuid,

--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -19,6 +19,7 @@ import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 import { isDisplayedField, isMandatoryField } from '@/utils/ADempiere/dictionary/window.js'
 import { DISPLAY_COLUMN_PREFIX, getDefaultValue } from '@/utils/ADempiere/dictionaryUtils.js'
 import { getContext } from '@/utils/ADempiere/contextUtils'
+import { isLookup } from '@/utils/ADempiere/references'
 
 /**
  * Dictionary Window Getters
@@ -230,7 +231,7 @@ export default {
         attributesObject[columnName] = parsedDefaultValue
 
         // add display column to default
-        if (isAddDisplayColumn && fieldItem.componentPath === 'FieldSelect') {
+        if (isAddDisplayColumn && isLookup(fieldItem.displayType)) {
           const { displayColumnName } = fieldItem
           let displayedValue
           if (!isEmptyValue(parsedDefaultValue)) {

--- a/src/store/modules/ADempiere/panel/actions.js
+++ b/src/store/modules/ADempiere/panel/actions.js
@@ -386,6 +386,7 @@ const actions = {
       containerManager.actionPerformed({
         containerUuid: field.containerUuid,
         field,
+        columnName,
         value,
         recordUuid
       })

--- a/src/store/modules/ADempiere/panel/getters.js
+++ b/src/store/modules/ADempiere/panel/getters.js
@@ -29,6 +29,7 @@ import {
   fieldIsDisplayed,
   getDefaultValue
 } from '@/utils/ADempiere/dictionaryUtils.js'
+import { isLookup } from '@/utils/ADempiere/references'
 
 const getters = {
   getPanel: (state) => (containerUuid) => {
@@ -338,7 +339,7 @@ const getters = {
         }
 
         // add display column to default
-        if (fieldItem.componentPath === 'FieldSelect') {
+        if (isLookup(fieldItem.displayType)) {
           const { displayColumnName } = fieldItem
           let displayedValue
           if (!isEmptyValue(parsedDefaultValue)) {

--- a/src/utils/ADempiere/constants/actionsMenuList.js
+++ b/src/utils/ADempiere/constants/actionsMenuList.js
@@ -23,6 +23,7 @@ import { clientDateTime } from '@/utils/ADempiere/formatValue/dateFormat.js'
 import { copyToClipboard } from '@/utils/ADempiere/coreUtils.js'
 import { exportFileFromJson, supportedTypes } from '@/utils/ADempiere/exportUtil.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
+import { isLookup } from '@/utils/ADempiere/references'
 
 /**
  * Shared url link
@@ -103,7 +104,7 @@ export const exportRecords = ({ parentUuid, containerUuid, containerManager, for
   })
 
   const columnsAvalable = fieldsListAvailable.map(fieldItem => {
-    if (fieldItem.componentPath === 'FieldSelect') {
+    if (isLookup(fieldItem.displayType)) {
       return fieldItem.displayColumnName
     }
     return fieldItem.columnName

--- a/src/utils/ADempiere/dictionary/panel.js
+++ b/src/utils/ADempiere/dictionary/panel.js
@@ -137,6 +137,7 @@ export function generatePanelAndFields({
     containerUuid,
     // tab attributes
     tabTableName: panelMetadata.tableName,
+    panelName: panelMetadata.name,
     // app attributes
     isShowedFromUser: true,
     isReadOnlyFromForm: false,

--- a/src/utils/ADempiere/dictionary/process.js
+++ b/src/utils/ADempiere/dictionary/process.js
@@ -88,6 +88,7 @@ export function generateProcess({
   const panelType = processToGenerate.isReport ? 'report' : 'process'
   const additionalAttributes = {
     containerUuid: processToGenerate.uuid,
+    panelName: processToGenerate.name,
     isEvaluateValueChanges: true,
     panelType
   }

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -834,9 +834,10 @@ export const containerManager = {
     })
   },
 
-  actionPerformed: ({ field, value }) => {
+  actionPerformed: ({ field, columnName, value }) => {
     return store.dispatch('actionPerformed', {
       field,
+      columnName,
       value
     })
       .then(response => {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `User` window.
2. Show `Business Partner` field.

A. Without save changes.
1. Select a record without `Business Partner`.
2. Set any `Business Partner`.

B. Without clear displayed value.
1. Select a record with `Business Partner`.
2. Click on `New`.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/180478646-5ec2e1ae-4ade-474e-8b01-f04c3324eb27.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/180478650-9c22606a-db49-4c79-abb4-cc047f7a6eac.mp4

#### Expected behavior
A. When fill `Business Partner` field, change value and `Save` are displayed.
B. When clic on `New` button, clear old set value.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes: https://github.com/solop-develop/frontend-core/issues/247
Depends on https://github.com/solop-develop/backend/pull/38
Depends on https://github.com/solop-develop/frontend-default-theme/pull/118
