### PR TITLE
fix: Logic on other tab or container.

### DIFF
--- a/src/store/modules/ADempiere/field.js
+++ b/src/store/modules/ADempiere/field.js
@@ -134,7 +134,7 @@ const field = {
     },
     getFieldFromElementColumnName: (state) => (elementColumnName) => {
       return state.fieldsList.find(fieldItem => {
-        return fieldItem.elementColumnName === elementColumnName
+        return fieldItem.elementName === elementColumnName
       })
     },
     getFieldFromTableNameAndColumnName: (state) => ({

--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -342,6 +342,7 @@ const windowManager = {
                 attributes
               })
 
+              // TODO: Evaluate seek record on container manager
               // active logics with set records values
               fieldsList.forEach(field => {
                 // change Dependents

--- a/src/utils/ADempiere/apiConverts/field.js
+++ b/src/utils/ADempiere/apiConverts/field.js
@@ -30,6 +30,12 @@ export function convertField(field) {
   if (field.process) {
     convertedField.process = convertProcess(field.process)
   }
+
+  convertedField.dependentFieldsList = convertedField.dependentFields.map(dependetField => {
+    return camelizeObjectKeys(dependetField)
+  })
+  delete convertedField['dependentFields']
+
   renameObjectKey(convertedField, 'columnSql', 'columnSQL')
   return convertedField
 }

--- a/src/utils/ADempiere/dictionary/panel.js
+++ b/src/utils/ADempiere/dictionary/panel.js
@@ -195,7 +195,8 @@ export function generatePanelAndFields({
     fieldsList = fieldsList.concat(fieldsRangeList)
   }
 
-  fieldsList = generateDependenFieldsList(fieldsList)
+  // get from server
+  // fieldsList = generateDependenFieldsList(fieldsList)
 
   identifierColumns = sortFields({
     fieldsList: identifierColumns,
@@ -262,6 +263,7 @@ export function generatePanelAndFields({
 /**
  * Get dependent fields on all elemnets
  * TODO: Improve performance and reduce array cycles
+ * TODO: Add dependents on all tabs to window container
  * @param {array} fieldsList
  * @returns {array}
  */

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -185,7 +185,7 @@ export function generateField({
     ...evaluatedLogics,
     //
     parentFieldsList,
-    dependentFieldsList: [],
+    // dependentFieldsList: [],
     // TODO: Add support on server
     // app attributes
     isShowedFromUser: false,

--- a/src/utils/ADempiere/lookupFactory.js
+++ b/src/utils/ADempiere/lookupFactory.js
@@ -134,7 +134,7 @@ export function createFieldFromDictionary({
               uuid,
               columnUuid,
               elementUuid,
-              elementColumnName,
+              elementName: elementColumnName,
               tableName,
               columnName,
               ...overwriteDefinition
@@ -267,6 +267,7 @@ export function getFieldTemplate(overwriteDefinition) {
     help: '',
     columnName: '',
     displayColumnName: DISPLAY_COLUMN_PREFIX + overwriteDefinition.columnName, // key to display column
+    elementName: '',
     fieldGroup: {
       name: '',
       fieldGroupType: ''
@@ -327,6 +328,10 @@ export function getFieldTemplate(overwriteDefinition) {
     isShowedFromUser: false,
     isFixedTableColumn: false,
     ...overwriteDefinition
+  }
+
+  if (isEmptyValue(fieldTemplateMetadata.elementName) && !isEmptyValue(fieldTemplateMetadata.columnName)) {
+    fieldTemplateMetadata.elementColumnName = fieldTemplateMetadata.columnName
   }
 
   // get parsed parent fields list


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `GardenWorld Admin` role
2. Open `Payroll Concept Catalog`
3. Change `Type` field on `Concept` tab to `Rule` value.
4. Showed `Rule` field on `Concept Attribute` tab.
5. Change `Type` field on `Concept` tab to `Concept` value. 

#### Screenshot or Gif

Before changes:

https://user-images.githubusercontent.com/20288327/184255959-b33634f9-7584-47dc-9d0f-9f3df2de36ff.mp4

After changes:

https://user-images.githubusercontent.com/20288327/184255919-7766a92b-e889-423c-be89-2022a78de29a.mp4

#### Expected behavior
The `Rule` field on the `Concept Attribute` tab is expected to be displayed when the Type field on the `Concept` tab is set to `Rule` value.


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Fixes https://github.com/solop-develop/frontend-core/issues/251
