### PR TITLE
fix: Currency rate with same currency.

### DIFF
--- a/src/api/ADempiere/system-core.js
+++ b/src/api/ADempiere/system-core.js
@@ -254,7 +254,7 @@ export function requestListBusinessPartner({
 }
 
 /**
- * TODO: Add uuid support
+ * Get currency rate
  * @param {string} conversionTypeUuid
  * @param {string} currencyFromUuid
  * @param {string} currencyToUuid

--- a/src/lang/ADempiere/en/form/pointOfSales.js
+++ b/src/lang/ADempiere/en/form/pointOfSales.js
@@ -1,0 +1,25 @@
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const pointOfSales = {
+  conversionRate: {
+    withoutConversionRate: 'There is no current exchange rate '
+  }
+}
+
+export default pointOfSales

--- a/src/lang/ADempiere/en/index.js
+++ b/src/lang/ADempiere/en/index.js
@@ -28,6 +28,7 @@ import smartBrowser from './smartBrowser'
 import window from './window'
 import actionNotice from './form/actionNotice'
 import payrollActionNotice from './form/payrollActionNotice'
+import pointOfSales from './form/pointOfSales'
 
 export default {
   actionMenu,
@@ -41,6 +42,7 @@ export default {
   smartBrowser,
   actionNotice,
   payrollActionNotice,
+  pointOfSales,
 
   language: 'Language',
   notifications: {

--- a/src/lang/ADempiere/es/form/pointOfSales.js
+++ b/src/lang/ADempiere/es/form/pointOfSales.js
@@ -1,0 +1,25 @@
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const pointOfSales = {
+  conversionRate: {
+    withoutConversionRate: 'No existe tasa de cambio registrada al dia '
+  }
+}
+
+export default pointOfSales

--- a/src/lang/ADempiere/es/index.js
+++ b/src/lang/ADempiere/es/index.js
@@ -28,6 +28,7 @@ import smartBrowser from './smartBrowser'
 import window from './window'
 import actionNotice from './form/actionNotice'
 import payrollActionNotice from './form/payrollActionNotice'
+import pointOfSales from './form/pointOfSales'
 
 export default {
   actionMenu,
@@ -41,6 +42,7 @@ export default {
   smartBrowser,
   actionNotice,
   payrollActionNotice,
+  pointOfSales,
 
   language: 'Idioma',
   notifications: {

--- a/src/store/modules/ADempiere/pointOfSales/payments/actions.js
+++ b/src/store/modules/ADempiere/pointOfSales/payments/actions.js
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import lang from '@/lang'
+
+// api request methods
 import {
   requestGetConversionRate,
   createPayment,
@@ -29,6 +32,9 @@ import {
   listRefundReference,
   deleteRefundReference
 } from '@/api/ADempiere/form/point-of-sales.js'
+
+// utils and helper methods
+import { formatDate } from '@/utils/ADempiere/formatValue/dateFormat'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { showMessage } from '@/utils/ADempiere/notification.js'
 
@@ -123,7 +129,7 @@ export default {
     const payment = state.paymentBox
     payment.splice(0)
   },
-  searchConversion({ commit, rootGetters }, params) {
+  searchConversion({ commit, getters, rootGetters }, params) {
     const posUuid = isEmptyValue(params.currentPOS) ? rootGetters.posAttributes.currentPointOfSales.uuid : params.currentPOS.uuid
     return requestGetConversionRate({
       posUuid,
@@ -133,6 +139,29 @@ export default {
       conversionDate: params.conversionDate
     })
       .then(response => {
+        if (isEmptyValue(response) || response.id <= 0) {
+          let conversionDate = params.conversionDate
+          if (isEmptyValue(conversionDate)) {
+            conversionDate = formatDate(new Date())
+          }
+          const currencyFrom = getters.getCurrenciesList.find(currency => {
+            return currency.uuid === params.currencyFromUuid
+          })
+          const currencyTo = getters.getCurrenciesList.find(currency => {
+            return currency.uuid === params.currencyToUuid
+          })
+
+          showMessage({
+            type: 'warning',
+            message: lang.t('pointOfSales.conversionRate.withoutConversionRate') + conversionDate + ', ' +
+              currencyFrom.currency_symbol + ' => ' + currencyTo.currency_symbol
+          })
+          console.warn(
+            lang.t('pointOfSales.conversionRate.withoutConversionRate') + conversionDate + ', ' +
+            currencyFrom.currency_symbol + ' => ' + currencyTo.currency_symbol
+          )
+        }
+
         commit('addConversionToList', response)
         return response
       })
@@ -145,7 +174,7 @@ export default {
         })
       })
   },
-  conversionDivideRate({ commit, dispatch, rootGetters }, params) {
+  conversionDivideRate({ commit, dispatch, getters, rootGetters }, params) {
     const posUuid = isEmptyValue(params.currentPOS) ? rootGetters.posAttributes.currentPointOfSales.uuid : params.currentPOS.uuid
     return requestGetConversionRate({
       posUuid,
@@ -155,6 +184,28 @@ export default {
       conversionDate: params.conversionDate
     })
       .then(response => {
+        if (isEmptyValue(response) || response.id <= 0) {
+          let conversionDate = params.conversionDate
+          if (isEmptyValue(conversionDate)) {
+            conversionDate = formatDate(new Date())
+          }
+          const currencyFrom = getters.getCurrenciesList.find(currency => {
+            return currency.uuid === params.currencyFromUuid
+          })
+          const currencyTo = getters.getCurrenciesList.find(currency => {
+            return currency.uuid === params.currencyToUuid
+          })
+
+          showMessage({
+            type: 'warning',
+            message: lang.t('pointOfSales.conversionRate.withoutConversionRate') + conversionDate + ', ' +
+              currencyFrom.currency_symbol + ' => ' + currencyTo.currency_symbol
+          })
+          console.warn(
+            lang.t('pointOfSales.conversionRate.withoutConversionRate') + conversionDate + ', ' +
+            currencyFrom.currency_symbol + ' => ' + currencyTo.currency_symbol
+          )
+        }
         commit('setFieldCurrency', response.currencyTo)
         if (!isEmptyValue(response.currencyTo)) {
           const currency = {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

http://0.0.0.0:8085/api/adempiere/common/conversion-rate?pos_uuid=c2828298-607f-49e9-b0c1-54ab020890d6&conversion_type_uuid=f11f895c-2b0c-4b65-9a1e-782f3f0df850&currency_from_uuid=a567befe-fb40-11e8-a479-7a0060f0aa01&currency_to_uuid=a567befe-fb40-11e8-a479-7a0060f0aa01&conversion_date=2022-08-30&token=50c71b91-8b5c-4a5e-b188-1e989430c470&language=es

![Screenshot_20220830_135820](https://user-images.githubusercontent.com/20288327/187509540-c74d69d5-e93d-4605-b786-ad068970bdf3.png)

```
No existe tasa de cambio registrada al dia 2022-08-30, Bs.S => Bs.S
```

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.


