### PR TITLE
fix: WF document action entity and record key.

### DIFF
--- a/src/views/ADempiere/Window/DocumentWindow.vue
+++ b/src/views/ADempiere/Window/DocumentWindow.vue
@@ -187,8 +187,8 @@ export default defineComponent({
     })
     const additionalOptions = ref({})
 
-    function loaDocument(params) {
-      if (isEmptyValue(recordUuid.value)) {
+    function loaDocument() {
+      if (isEmptyValue(recordUuid.value) || recordUuid.value === 'create-new') {
         return
       }
       store.dispatch('listDocumentActionStatus', {
@@ -205,7 +205,7 @@ export default defineComponent({
     }
 
     watch(recordUuid, (newValue, oldValue) => {
-      if (newValue !== oldValue && !isEmptyValue(newValue)) {
+      if (newValue !== oldValue && !isEmptyValue(newValue) && newValue !== 'create-new') {
         loaDocument()
         store.dispatch('listDocumentStatus', {
           tableName: referencesManager.value.getTableName(),


### PR DESCRIPTION
http://0.0.0.0:8085/api/adempiere/workflow/document-actions?uuid=create-new&table_name=R_Request&pageToken=&pageSize=0&token=ce190db2-11b8-4bf8-baf2-45c1da98646e&language=es

Before this changes:

```log
===========> WorkflowServiceImplementation.listDocumentActions: Cannot invoke "org.compiere.model.PO.get_ValueAsString(String)" because "entity" is null [30]
```


After this changes:
```log
===========> WorkflowServiceImplementation.listDocumentActions: Error:  PO * No encontrado * [37]
```
![Screenshot_20220831_123326](https://user-images.githubusercontent.com/20288327/187731469-26c8d21a-727b-4fdf-8c7a-9933aab50ead.png)

Related change https://github.com/solop-develop/backend/pull/82