### PR TITLE
fix: Show qty on order line.

### DIFF
--- a/src/lang/ADempiere/en/index.js
+++ b/src/lang/ADempiere/en/index.js
@@ -444,6 +444,8 @@ export default {
       tableProduct: {
         product: 'Product',
         quantity: 'Quantity',
+        uom: 'UOM',
+        unitOfMeasure: 'Unit of Measure',
         options: 'Options',
         editQuantities: 'Edit Quantities',
         pin: 'Insert Pin',

--- a/src/lang/ADempiere/es/index.js
+++ b/src/lang/ADempiere/es/index.js
@@ -419,6 +419,8 @@ export default {
       tableProduct: {
         product: 'Producto',
         quantity: 'Cantidad',
+        uom: 'UM',
+        unitOfMeasure: 'Unidad de Medida',
         options: 'Opciones',
         editQuantities: 'Editar Cantidades',
         pin: 'Ingrese Pin',


### PR DESCRIPTION
Before this changes:

![Screenshot_20220905_141452](https://user-images.githubusercontent.com/20288327/188505721-a0133c5e-9812-40b9-ab42-1d08a9ef1106.png)

After this changes:

![Screenshot_20220905_153412](https://user-images.githubusercontent.com/20288327/188505719-a8910f55-91ca-4267-b21c-ab894733482d.png)

#### Additional context:

Depends on https://github.com/solop-develop/frontend-default-theme/pull/235
