### PR TITLE
fix: POS Multiple request with search order list.

### DIFF
--- a/src/store/modules/ADempiere/pointOfSales/order/actions.js
+++ b/src/store/modules/ADempiere/pointOfSales/order/actions.js
@@ -232,18 +232,18 @@ export default {
    * Set page number of pagination list
    * @param {number}  pageNumber
    */
-  setOrdersListPageNumber({ commit, dispatch }, pageNumber) {
-    commit('setOrdersListPageNumber', pageNumber)
-    dispatch('listOrdersFromServer', {})
-  },
   listOrdersFromServer({ state, commit, getters }, {
-    posUuid
+    posUuid,
+    pageNumber
   }) {
     if (isEmptyValue(posUuid)) {
       posUuid = getters.posAttributes.currentPointOfSales.uuid
     }
 
-    const { pageNumber } = state.listOrder
+    if (isEmptyValue(pageNumber) || pageNumber <= 0) {
+      // refresh with same page
+      pageNumber = state.listOrder.pageNumber
+    }
     const pageToken = generatePageToken({ pageNumber })
 
     let values = getters.getValuesView({

--- a/src/store/modules/ADempiere/pointOfSales/order/mutations.js
+++ b/src/store/modules/ADempiere/pointOfSales/order/mutations.js
@@ -27,9 +27,6 @@ export default {
       ...listOrder
     }
   },
-  setOrdersListPageNumber(state, pageNumber) {
-    state.listOrder.pageNumber = pageNumber
-  },
   showListOrders(state, isShow) {
     state.listOrder.isShowPopover = isShow
   },


### PR DESCRIPTION
- Reduce from 4 request to 1 request with search orders list.
- Add refresh orders list button.

https://user-images.githubusercontent.com/20288327/189447679-48180779-ae30-4850-9e53-f5e02e3fff31.mp4

