### PR TITLE
fix: Load records on tab childs.

### DIFF
--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -48,12 +48,13 @@ const initState = {
     contextKey: '',
     searchValue: '',
     currentRecordUuid: undefined,
-    recordsList: [],
-    selectionsList: [],
+    recordsList: [], // list of response records
+    selectionsList: [], // record selection
     nextPageToken: undefined,
-    recordCount: 0,
-    isLoaded: false,
-    pageNumber: 1
+    recordCount: 0, // total number of all records
+    isLoaded: false, // has not been charged the first time
+    isLoading: false, // request currently in progress
+    pageNumber: 1 // page number of records
   }
 }
 
@@ -72,6 +73,7 @@ const windowManager = {
       nextPageToken,
       recordCount = 0,
       isLoaded = true,
+      isLoading = false,
       pageNumber = 1
     }) {
       const dataTab = {
@@ -85,6 +87,7 @@ const windowManager = {
         nextPageToken,
         recordCount,
         isLoaded,
+        isLoading,
         pageNumber
       }
       Vue.set(state.tabData, containerUuid, dataTab)
@@ -175,6 +178,13 @@ const windowManager = {
       searchValue
     }) {
       Vue.set(state.tabData[containerUuid], 'searchValue', searchValue)
+    },
+
+    setIsLoadingTabRecordsList(state, {
+      containerUuid,
+      isLoading
+    }) {
+      Vue.set(state.tabData[containerUuid], 'isLoading', isLoading)
     },
 
     resetStateWindowManager(state) {
@@ -287,6 +297,11 @@ const windowManager = {
         })
 
         const currentRoute = router.app._route
+
+        commit('setIsLoadingTabRecordsList', {
+          containerUuid,
+          isLoading: true
+        })
         getEntities({
           windowUuid: parentUuid,
           tabUuid: containerUuid,
@@ -371,6 +386,7 @@ const windowManager = {
               nextPageToken: dataResponse.nextPageToken,
               pageNumber,
               isLoaded: true,
+              isLoading: false,
               recordCount: dataResponse.recordCount
             })
 
@@ -382,6 +398,10 @@ const windowManager = {
               parentUuid,
               isLoaded: true,
               containerUuid
+            })
+            commit('setIsLoadingTabRecordsList', {
+              containerUuid,
+              isLoading: false
             })
             resolve([])
           })


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `GardenAdmin` role.
2. Open `Business Partner` window.
3. Click on different child tabs.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/191795329-c039d3ad-603f-424c-a53d-e19c8d088d1d.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/191795322-a128dcea-5f8a-4032-ad9a-f0e8c7e4f8f8.mp4

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.20.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.


