### PR TITLE
fixed: Set empty Date field.

### DIFF
--- a/src/utils/ADempiere/formatValue/dateFormat.js
+++ b/src/utils/ADempiere/formatValue/dateFormat.js
@@ -193,7 +193,9 @@ export function changeTimeZone({
   }
 
   let date = value
-  if (typeof value === 'string') {
+  if (isEmptyValue(date)) {
+    date = new Date()
+  } if (typeof value === 'string') {
     // TODO: Verify it time zone
     if (value.length <= 10) {
       value += 'T00:00:00' // without time zone


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window with Date field.
2. Set any date value.

#### Screenshot or Gif


https://user-images.githubusercontent.com/20288327/192055121-ed0d21bc-fdde-4e90-a1a3-20f27ae13a31.mp4


https://user-images.githubusercontent.com/20288327/192055129-3a6a84a3-6a26-436c-b0f0-01e75cc2296d.mp4



#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.20.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

