### PR TITLE
feat: POS Add empty translations.

### DIFF
--- a/src/lang/ADempiere/en/form/pointOfSales.js
+++ b/src/lang/ADempiere/en/form/pointOfSales.js
@@ -35,6 +35,21 @@ const pointOfSales = {
   keyLayout: {
     quantity: 'Quantity'
   },
+  order: {
+    dateOfOrder: 'Date of Order',
+    documentType: 'Document Type'
+  },
+  orderLine: {
+    edit: 'Line Edit',
+    updateSuccess: 'Order Line Successfully Updated'
+  },
+  pin: {
+    validatePin: 'Validate PIN',
+    validateSuccessfully: 'PIN Validate Successfully'
+  },
+  print: {
+    cloudNotConnectPirnter: 'Could not connect to the printer'
+  },
   withoutPOSTerminal: 'Without POS Terminal',
   withoutPriceList: 'Without Price List'
 }

--- a/src/lang/ADempiere/en/index.js
+++ b/src/lang/ADempiere/en/index.js
@@ -46,6 +46,7 @@ export default {
   payrollActionNotice,
   pointOfSales,
 
+  edit: 'Edit',
   language: 'Language',
   notifications: {
     // simplex

--- a/src/lang/ADempiere/es/form/pointOfSales.js
+++ b/src/lang/ADempiere/es/form/pointOfSales.js
@@ -35,6 +35,21 @@ const pointOfSales = {
   keyLayout: {
     quantity: 'Cantidad'
   },
+  order: {
+    dateOfOrder: 'Fecha de Orden',
+    documentType: 'Tipo de Documento'
+  },
+  orderLine: {
+    edit: 'Editar Línea',
+    updateSuccess: 'Linea de la Orden Actualizada Exitosamente'
+  },
+  pin: {
+    validatePin: 'Validar PIN',
+    validateSuccessfully: 'PIN Validado Exitosamente'
+  },
+  print: {
+    cloudNotConnectPirnter: 'No se ha podido conectar con la impresora'
+  },
   withoutPOSTerminal: 'Sin Terminal POS',
   withoutPriceList: 'Sin Lista de Precios'
 }

--- a/src/lang/ADempiere/es/index.js
+++ b/src/lang/ADempiere/es/index.js
@@ -46,6 +46,7 @@ export default {
   payrollActionNotice,
   pointOfSales,
 
+  edit: 'Editar',
   language: 'Idioma',
   notifications: {
     // simplex


### PR DESCRIPTION
Translations that were not added and were directly in Spanish are added

#### Additional context
Depends on https://github.com/solop-develop/frontend-default-theme/pull/300