### PR TITLE
Change the maximum number of lines

### DIFF
--- a/src/api/ADempiere/form/point-of-sales.js
+++ b/src/api/ADempiere/form/point-of-sales.js
@@ -429,7 +429,7 @@ export function deleteOrderLine({
 export function listOrderLines({
   posUuid,
   orderUuid,
-  pageSize,
+  pageSize = 50,
   pageToken
 }) {
   return request({


### PR DESCRIPTION
### Change the maximum number of lines

Minimum registration quantity increased to 50 when consulting the lines at the point of sale since it does not have pagination. 