### PR TITLE
fixed: SB Field Search query criteria.

### DIFF
--- a/src/utils/ADempiere/dictionary/browser.js
+++ b/src/utils/ADempiere/dictionary/browser.js
@@ -358,7 +358,7 @@ export const containerManager = {
       parentUuid,
       containerUuid,
       contextColumnNames,
-      processParameterUuid: uuid,
+      browseFieldUuid: uuid,
       tableName,
       columnName,
       filters,

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -173,6 +173,7 @@ export function generateField({
     ...moreAttributes,
     columnNameTo: undefined,
     elementNameTo: undefined,
+    isSameColumnElement: columnName === fieldToGenerate.elementColumnName,
     isSOTrxMenu,
     // displayed attributes
     componentPath: componentReference.componentPath,

--- a/src/utils/ADempiere/references.js
+++ b/src/utils/ADempiere/references.js
@@ -334,6 +334,14 @@ export const FIELDS_LOOKUP = [
   RESOURCE_ASSIGNMENT.id
 ]
 
+export const SUPPORTED_LOOKUPS = [
+  ACCOUNT_ELEMENT.id,
+  LIST.id,
+  TABLE.id,
+  TABLE_DIRECT.id,
+  SEARCH.id
+]
+
 // Some helper methods
 export function isLookup(displayType) {
   return FIELDS_LOOKUP.includes(displayType)
@@ -496,3 +504,18 @@ export function isIntegerField(displayType) {
 export function isDecimalField(displayType) {
   return FIELDS_DECIMALS.includes(displayType)
 }
+
+export const FIELDS_FILE = [
+  BINARY_DATA.id,
+  IMAGE.id,
+  LOCAL_FILE.id,
+  LOCAL_FILE_PATH.id,
+  LOCAL_FILE_PATH_OR_NAME.id
+]
+
+export const FIELDS_TEXT = [
+  CHAR.id,
+  MEMO.id,
+  TEXT.id,
+  TEXT_LONG.id
+]


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `Garden Admin` role.
2. Open `User Browser` smart browser.
3. Show `Business Partner` query criteria.
4. Set any value in `Business Partner` field.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/193020913-103e4805-8bd3-49db-a9f6-7dd3d8a0e08f.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/193020915-b3103fb5-a4e3-4b73-9c1a-7cbf8c6c69e9.mp4

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.20.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.


