### PR TITLE
fix: Cache list lookups.

### DIFF
--- a/src/store/modules/ADempiere/defaultValueManager.js
+++ b/src/store/modules/ADempiere/defaultValueManager.js
@@ -12,7 +12,7 @@
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import Vue from 'vue'
 

--- a/src/store/modules/ADempiere/defaultValueManager.js
+++ b/src/store/modules/ADempiere/defaultValueManager.js
@@ -1,6 +1,6 @@
 // ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
-// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
-// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/src/store/modules/ADempiere/lookupManager.js
+++ b/src/store/modules/ADempiere/lookupManager.js
@@ -12,7 +12,7 @@
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import Vue from 'vue'
 import lang from '@/lang'

--- a/src/store/modules/ADempiere/lookupManager.js
+++ b/src/store/modules/ADempiere/lookupManager.js
@@ -1,6 +1,6 @@
 // ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
-// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
-// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/src/store/modules/ADempiere/lookupManager.js
+++ b/src/store/modules/ADempiere/lookupManager.js
@@ -188,6 +188,7 @@ const lookupManager = {
       containerUuid,
       uuid,
       contextColumnNames = [],
+      contextColumnNamesByDefaultValue = [],
       value
     }) {
       return new Promise(resolve => {
@@ -195,7 +196,7 @@ const lookupManager = {
           parentUuid,
           containerUuid,
           uuid,
-          contextColumnNames,
+          contextColumnNames: contextColumnNamesByDefaultValue,
           value
         })
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `Garden Admin` role.
2. Open `Business Partner Group` window.
3. Show `Organization` field.
4. Click on `New` button.
5. List `Organization` field list.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/193479169-cb001a3c-521b-4a0a-ae9a-5fe5d71fde75.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/193479178-939542e7-6ef0-4ce0-9a61-79d89d2ac626.mp4


#### Expected behavior

If you load a default value in a lookup type field and then list that field, not all records are listed but only the one loaded through the default value.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.20.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Add any other context about the problem here.
