### PR TITLE
fix: Field search table showed no displayed colum.

### DIFF
--- a/src/store/modules/ADempiere/form/generalInfoSearch.js
+++ b/src/store/modules/ADempiere/form/generalInfoSearch.js
@@ -305,7 +305,7 @@ const generalInfoSearch = {
                 // without search, table, and table direct references
                 return ![SEARCH.id, TABLE.id, TABLE_DIRECT.id].includes(field.displayType) &&
                   // key is used to seleccion column, unnused on vue client
-                  !field.isKey
+                  !field.isKey && field.isDisplayed
               })
               .sort((fieldA, fieldB) => {
                 // https://github.com/adempiere/adempiere/blob/develop/client/src/org/compiere/apps/search/InfoGeneral.java#L332


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `Garden Admin` role.
2. Open `Shipment (Customer)` window.
3. Show `Order` field.
4. List `Orders` records on search field.

In the search type fields, no hidden fields such as UUID should be displayed when displaying the table of records. 

#### Screenshot or Gif
Before this changes:

![Screenshot_20221006_232909](https://user-images.githubusercontent.com/20288327/194462478-703d2728-a718-43c5-8f2e-6923080be4be.png)

After this changes:

![Screenshot_20221006_233104](https://user-images.githubusercontent.com/20288327/194462499-dd171dab-22c4-4f26-a7da-df3c4867682f.png)


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.20.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

