### PR TITLE
fix: Time control corrections.

### DIFF
--- a/src/api/ADempiere/form/timeControl.js
+++ b/src/api/ADempiere/form/timeControl.js
@@ -45,6 +45,7 @@ export function requestCreateResource({
       return camelizeObjectKeys(response)
     })
 }
+
 export function requestUpdateResource({
   id,
   uuid,
@@ -67,6 +68,7 @@ export function requestUpdateResource({
       return camelizeObjectKeys(response)
     })
 }
+
 export function requestDeleteResource({
   id,
   uuid
@@ -86,18 +88,22 @@ export function requestDeleteResource({
       return camelizeObjectKeys(response)
     })
 }
+
 export function requestListResource({
   resourceTypeId,
   resourceTypeUuid,
   name,
   description,
   isWaitingForOrdered,
+  confirmed,
+  pageSize = 25,
   pageToken
 }) {
   return request({
     url: '/form/addons/time-control/list-resources-assignment',
     method: 'post',
     params: {
+      page_size: pageSize,
       page_token: pageToken
     },
     data: {
@@ -106,8 +112,8 @@ export function requestListResource({
       resource_type_uuid: resourceTypeUuid,
       is_waiting_for_ordered: isWaitingForOrdered,
       name,
-      description
-      // page_size: 25
+      description,
+      confirmed
     }
   })
     .then(response => {
@@ -115,6 +121,7 @@ export function requestListResource({
       return camelizeObjectKeys(response)
     })
 }
+
 export function requestConfirmResourceAssignnment({
   id,
   uuid

--- a/src/lang/ADempiere/en/form/timeControl.js
+++ b/src/lang/ADempiere/en/form/timeControl.js
@@ -15,6 +15,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const timeControl = {
+  confirm: 'Cofirm',
+  confirmed: 'Confirmed',
+  confirmProcessRecord: 'Are you sure you want to confirm this record?',
   type: 'Type',
   name: 'Name',
   input: 'Input',
@@ -25,7 +28,8 @@ const timeControl = {
   area: 'Área',
   addChild: 'Add',
   recordConfirmed: 'Record Confirmed',
-  addResource: 'Add Resources'
+  addResource: 'Add Resources',
+  searchRecords: 'Search Records'
 }
 
 export default timeControl

--- a/src/lang/ADempiere/es/form/timeControl.js
+++ b/src/lang/ADempiere/es/form/timeControl.js
@@ -15,6 +15,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const timeControl = {
+  confirm: 'Confirmar',
+  confirmed: 'Confirmado',
+  confirmProcessRecord: '¿Está seguro que quiere confirmar este registro?',
   type: 'Tipo',
   name: 'Nombre',
   input: 'Entrada',
@@ -25,7 +28,8 @@ const timeControl = {
   area: 'Área',
   addChild: 'Agregar',
   recordConfirmed: 'Registro Confirmado',
-  addResource: 'Agregar Recursos'
+  addResource: 'Agregar Recursos',
+  searchRecords: 'Búscar Registros'
 }
 
 export default timeControl

--- a/src/router/modules/ADempiere/staticRoutes.js
+++ b/src/router/modules/ADempiere/staticRoutes.js
@@ -143,6 +143,24 @@ const staticRoutes = [
         }
       }
     ]
+  },
+
+  {
+    path: '/TimeControl',
+    component: Layout,
+    hidden: false,
+    children: [
+      {
+        path: '/TimeControl',
+        component: () => import('@/views/ADempiere/Form'),
+        name: 'TimeControl',
+        meta: {
+          title: 'TimeControl',
+          icon: 'search',
+          isIndex: true
+        }
+      }
+    ]
   }
 ]
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

#### Screenshot or Gif


https://user-images.githubusercontent.com/20288327/195086855-b61fab29-2b77-4c63-99df-a0b87e152ce1.mp4



#### Other relevant
- Double scroll.
- Display search fields by default.
- Confirm field to list.
- Confirm default value is 'N'.
- Time format `hh:mm:ss a`.
- Confirm dialog question.