### PR TITLE
Fix: Click on Related Document does not lead to registration

### DIFF
--- a/src/utils/ADempiere/filters.js
+++ b/src/utils/ADempiere/filters.js
@@ -156,7 +156,9 @@ class Filters {
 
       let type = 'STRING'
       let value = values[1]
-      if (value.includes('\'')) {
+      if (isEmptyValue(value)) {
+        value
+      } else if (value.includes('\'')) {
         value = value.replace(/'/g, '')
       } else {
         value = Number(value)


### PR DESCRIPTION
### ADempiere-UI


https://user-images.githubusercontent.com/45974454/195610860-559f0c33-1dca-49fc-8f2f-ae64e4db8cf0.mp4


### ADempiere-ZK


https://user-images.githubusercontent.com/45974454/195611196-d85a1ab6-67db-40b3-acdd-8fc20fa41ca5.mp4



### Issues

Fixed #487 #255 


### **_Nota_**
It is worth noting that both in the zk and in the UI it does not allow to zoom in on that particular record, so it is an ADempiere error.