### PR TITLE
feat: Location Address open map.

### DIFF
--- a/src/utils/ADempiere/dictionary/form/locationAddress.js
+++ b/src/utils/ADempiere/dictionary/form/locationAddress.js
@@ -43,7 +43,7 @@ export function getSequenceAsList(captureSequence) {
     .filter(value => value.trim())
 }
 
-export const URL_BASE_MAP = 'https://maps.google.com/?q='
+export const URL_BASE_MAP = 'https://www.google.com/maps?q='
 
 /**
  * Format coordenate form decimal number

--- a/src/utils/ADempiere/dictionary/form/locationAddress.js
+++ b/src/utils/ADempiere/dictionary/form/locationAddress.js
@@ -42,3 +42,16 @@ export function getSequenceAsList(captureSequence) {
     .split('@')
     .filter(value => value.trim())
 }
+
+export const URL_BASE_MAP = 'https://maps.google.com/?q='
+
+/**
+ * Format coordenate form decimal number
+ * @param {number} coordenate
+ * @returns {string}
+ */
+export function formatCoordinateByDecimal(coordenate) {
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 6
+  }).format(coordenate)
+}


### PR DESCRIPTION
Added support to open the google map based on the location address values, considering that in vue if it has coordinates it will take as priority those values for the search, in case of not having coordinates, it will perform a search with the display value of the address:

Example with coordinate values https://www.google.com/maps?q=10.046955,-69.325574

Example with display value https://www.google.com/maps?q=,+OR,+Furniture+Transit,+United+States


#### Zk Version:

https://user-images.githubusercontent.com/20288327/196710708-56bb342f-22c7-4122-86c0-f9634a5ea650.mp4



#### Vue Version:

https://user-images.githubusercontent.com/20288327/196710657-2f124994-e8c9-47b1-84d4-110e21959741.mp4

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/510
