### PR TITLE
fix: Save mandatory value and document no.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -325,7 +325,7 @@ export default {
     return fieldsList
       .filter(fieldItem => {
         const { defaultValue } = fieldItem
-        const isMandatory = fieldItem.isMandatory || fieldItem.isMandatoryFromLogic
+        const isMandatory = isMandatoryField(fieldItem)
 
         // parent column
         if (fieldItem.isParent) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

Case A:
1. Open `Product Category` window.
2. Create new record without `Value`.

Case B:
1. Open Sales Order window.
2. Create new record without `Document No`.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/197022605-c1386002-0c7b-4923-a946-9b590fa5c03e.mp4

https://user-images.githubusercontent.com/20288327/197022610-6880e237-054d-4628-8a87-2fb4c426e24f.mp4


#### Additional context
Fixes https://github.com/solop-develop/frontend-core/issues/514
