### PR TITLE
fix: 404 Page focus back button.

### DIFF
--- a/src/views/error-page/404.vue
+++ b/src/views/error-page/404.vue
@@ -14,7 +14,10 @@
         </div>
         <div class="bullshit__headline">{{ message }}</div>
         <div class="bullshit__info">Please check that the URL you entered is correct, or click the button below to return to the homepage.</div>
-        <a href="" class="bullshit__return-home">Back to home</a>
+
+        <a ref="backToHome" href="" class="bullshit__return-home">
+          Back to home
+        </a>
       </div>
     </div>
   </div>
@@ -28,6 +31,9 @@ export default {
     message() {
       return 'The webmaster said that you can not enter this page...'
     }
+  },
+  mounted() {
+    this.$refs['backToHome'].focus()
   }
 }
 </script>


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
When is 404 (not found) page, focus on back to home button.