### PR TITLE
Fix: Change maximum payment method registration available

### DIFF
--- a/src/api/ADempiere/form/point-of-sales.js
+++ b/src/api/ADempiere/form/point-of-sales.js
@@ -934,13 +934,15 @@ export function listCurrencies({
  * @param {string} posUuidd - POS UUID reference
  */
 export function listTenderTypes({
-  posUuid
+  posUuid,
+  pageSize = 50
 }) {
   return request({
     url: `${config.pointOfSales.endpoint}/available-payment-methods`,
     method: 'get',
     params: {
-      pos_uuid: posUuid
+      pos_uuid: posUuid,
+      page_size: pageSize
     }
   })
     .then(listTenderType => {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Change the maximum amount of registration when the list of payment methods was changed to 25
