### PR TITLE
fix: Window export records selected.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -34,6 +34,7 @@ import {
   generateWindow,
   createNewRecord,
   deleteRecord,
+  exportCurrentRecord,
   runProcessOfWindow,
   generateReportOfWindow,
   openBrowserAssociated,
@@ -45,7 +46,6 @@ import {
 import { panelAdvanceQuery } from '@/utils/ADempiere/dictionary/panel.js'
 import {
   exportRecordsSelected,
-  exportCurrentRecord,
   sharedLink
 } from '@/utils/ADempiere/constants/actionsMenuList.js'
 import evaluator from '@/utils/ADempiere/evaluator'
@@ -416,7 +416,16 @@ export default {
 
     actionsList.push(recordAccess)
     actionsList.push(exportCurrentRecord)
-    actionsList.push(exportRecordsSelected)
+    actionsList.push({
+      ...exportRecordsSelected,
+      // overwrite displayed method
+      displayed: ({ parentUuid, containerUuid }) => {
+        const currentTab = store.getters.getStoredTab(parentUuid, containerUuid)
+
+        // only multi record
+        return currentTab.isShowedTableRecords
+      }
+    })
     actionsList.push(sharedLink)
 
     commit('setActionMenu', {

--- a/src/utils/ADempiere/formatValue/stringFormat.js
+++ b/src/utils/ADempiere/formatValue/stringFormat.js
@@ -1,18 +1,20 @@
-// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
-// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
-// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
 
 /**
  * Capitalize value
@@ -23,4 +25,18 @@ export function capitalize(str) {
   // str is the argument passed to the helper when called
   str = str || ''
   return str.slice(0, 1).toUpperCase() + str.slice(1)
+}
+
+/**
+ * Decode HTML Entities
+ * - `&aacute;`  =  `á`
+ * - `&oacute;`  =  `ó`
+ * - `&ntilde;`  =  `ñ`
+ * @param {string} str string value
+ * @returns {string}
+ */
+export function decodeHtmlEntities(str) {
+  const titleField = new DOMParser().parseFromString(str, 'text/html')
+
+  return titleField.documentElement.textContent
 }

--- a/src/utils/ADempiere/valueFormat.js
+++ b/src/utils/ADempiere/valueFormat.js
@@ -1,18 +1,20 @@
-// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
-// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
-// Contributor(s): Yamel Senih ysenih@erpya.com www.erpya.com
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <https://www.gnu.org/licenses/>.
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
 
 // A util class for handle format for time, date and others values to beused to display information
 // Note that this file use moment library for a easy conversion
@@ -21,19 +23,20 @@
 import {
   DATE, DATE_PLUS_TIME, TIME,
   AMOUNT, COSTS_PLUS_PRICES, NUMBER, QUANTITY,
+  CHAR, MEMO, TEXT, TEXT_LONG,
   ACCOUNT_ELEMENT, LOCATION_ADDRESS, PRODUCT_ATTRIBUTE, // Custom lookups
   LIST, TABLE, TABLE_DIRECT, SEARCH, // Standard lookups
   YES_NO
 } from '@/utils/ADempiere/references.js'
 
 // utils and helper methods
-import { isEmptyValue, typeValue } from '@/utils/ADempiere/valueUtils.js'
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { convertBooleanToTranslationLang } from './formatValue/booleanFormat'
-
+export { convertObjectToKeyValue } from '@/utils/ADempiere/formatValue/iterableFormat'
+import { decodeHtmlEntities } from '@/utils/ADempiere/formatValue/stringFormat.js'
 // TODO: Duplicated exported method, removed this
 import { formatPrice as formatPriceTemp } from '@/utils/ADempiere/formatValue/numberFormat'
 import { formatDate as formatDateTemp } from '@/utils/ADempiere/formatValue/dateFormat'
-export { convertObjectToKeyValue } from '@/utils/ADempiere/formatValue/iterableFormat'
 
 // TODO: Duplicated method remove and use with destructured params
 export function formatDate(value, isTime = false, format) {
@@ -100,9 +103,6 @@ export function formatField({
       break
 
     case DATE.id:
-      if (typeValue(value) === 'DATE') {
-        value = value.getTime()
-      }
       formattedValue = formatDateTemp({
         value,
         isTime: false,
@@ -133,6 +133,13 @@ export function formatField({
 
     case YES_NO.id:
       formattedValue = convertBooleanToTranslationLang(value)
+      break
+
+    case CHAR.id:
+    case MEMO.id:
+    case TEXT.id:
+    case TEXT_LONG.id:
+      formattedValue = decodeHtmlEntities(value)
       break
 
     default:


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window with records.

Previously the tab actions were duplicated, now when in panel mode it shows only `Export Record`, while in table mode it shows `Export Selected Records`.

Additionally 2 bugs are fixed:
* The first one in the label name in the BE `Expansi&oacute;n LDM` column now shows `Expansi&oacute;n LDM`.
* The second in the date format previously `2020-01-22T04:00:00:00.000Z` now `01/22/2020`.


#### Screenshot or Gif
Before this changes:

![197896401-381068fd-622e-41d8-982d-bda1689c065f](https://user-images.githubusercontent.com/20288327/203544684-95368f6b-f576-4e69-a661-0bf2bc54a2be.png)

After this changes:

https://user-images.githubusercontent.com/20288327/203544776-d3c81f69-e3d9-425d-a5aa-9f5f70e4a080.mp4

#### Additional context
Exported file before changes
[Orden 2022-11-23 20 44 52.xls](https://github.com/solop-develop/frontend-core/files/10075378/Orden.2022-11-23.20.44.52.xls)

Exported file after changes 
[Orden 2022-11-23 21 45 42.xls](https://github.com/solop-develop/frontend-core/files/10075384/Orden.2022-11-23.21.45.42.xls)


Fixes https://github.com/solop-develop/frontend-core/issues/295

