### PR TITLE
Fix:  POS Change Translation Shipment

### DIFF
--- a/src/lang/ADempiere/es/index.js
+++ b/src/lang/ADempiere/es/index.js
@@ -399,7 +399,7 @@ export default {
           copyOrder: 'Copiar Orden',
           createNewReturnOrder: 'Crear una nueva orden de devolución',
           confirmDelivery: 'Confirmar Entrega',
-          deliverAllProducts: 'Entrega todos los productos',
+          deliverAllProducts: 'Entregar Todo',
           emptyProductDelivery: 'Producto no se Encuentra en la Orden'
         },
         cashManagement: {


### PR DESCRIPTION
Change translation of `Deliver all products` to `Deliver All
`
![image](https://user-images.githubusercontent.com/45974454/204907542-c4eec3c2-f1e0-46ae-b422-8ac538dcc916.png)