### PR TITLE
fix: Get default value with single quotes.

### DIFF
--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -9,7 +9,7 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -20,7 +20,7 @@ import language from '@/lang'
 
 // constants
 import { CLIENT } from '@/utils/ADempiere//constants/systemColumns'
-import { TABLE, TABLE_DIRECT } from '@/utils/ADempiere/references.js'
+import { LIST, TABLE, TABLE_DIRECT } from '@/utils/ADempiere/references.js'
 import { DISPLAY_COLUMN_PREFIX, IDENTIFIER_COLUMN_SUFFIX } from '@/utils/ADempiere/dictionaryUtils'
 import { OPERATION_PATTERN } from '@/utils/ADempiere/formatValue/numberFormat.js'
 
@@ -403,6 +403,12 @@ export function parsedValueComponent({
         (columnName.endsWith('_ID_To') || columnName.endsWith(IDENTIFIER_COLUMN_SUFFIX))) {
         if (!isEmptyValue(value)) {
           value = Number(value)
+        }
+      }
+      if (LIST.id === displayType) {
+        if (!isEmptyValue(value) && isNaN(value)) {
+          // remove single quotation mark 'DR' -> DR
+          value = value.replace(/(^\'|^\")(\w+)(\"|\')/g, '$2')
         }
       }
       // Search or List


### PR DESCRIPTION
#### Request

http://localhost:8085/api/adempiere/user-interface/window/default-value?field_uuid=8d8b5bba-fb40-11e8-a479-7a0060f0aa01&id=59390&value=%27DR%27&token=23b81174-fa45-40dc-8583-b176673f85eb&language=en&ts=1675266803201


#### Response

```json
{
  "code": 500,
  "result": ""
}
```

```log
===========> UserInterfaceServiceImplementation.getDefaultValue: null [206]
```

#### Before this changes

https://user-images.githubusercontent.com/20288327/216104449-037e12a6-9680-45be-a9da-634a1eeaa9d1.mp4


#### After this changes

https://user-images.githubusercontent.com/20288327/216104401-fc7422dc-5eb5-4bc3-a2c7-b6258570e9db.mp4




#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/818


