### PR TITLE
Fix: Failed to set server default

### DIFF
--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -1690,6 +1690,7 @@ export const containerManager = {
           })
         }
       }
+      return response
     })
   },
   getLookupList({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName, searchValue, isAddBlankValue, blankValue }) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
When it does not Get the default value it is not returning any structure which throws an error in the function (getDefaultValue)
#### Steps to reproduce

1. Open the Documents Payable window

2. Create a new Registry

3. Add a Business Partner
#### Screenshot or Gif

### Error

![Adempiere-Vue-Google-Chrome-2023-02-09-15-43-30](https://user-images.githubusercontent.com/45974454/217921653-b763e6e4-9379-4c86-8b63-be4919ea7d4f.gif)

### success
![Panel-de-control-Adempiere-Vue-Google-Chrome-2023-02-09-15-51-06](https://user-images.githubusercontent.com/45974454/217922538-677f348d-b141-4c6b-b5cd-530f451c0980.gif)



