### PR TITLE
fix: Smart Browser field YesNo without search.

### DIFF
--- a/src/store/modules/ADempiere/browserManager.js
+++ b/src/store/modules/ADempiere/browserManager.js
@@ -132,12 +132,10 @@ const browserControl = {
         }
 
         // Validate if a field is called and visible
-        if (isEmptyValue(field.dependentFieldsList)) {
-          dispatch('getBrowserSearch', {
-            containerUuid,
-            isClearSelection: true
-          })
-        }
+        dispatch('getBrowserSearch', {
+          containerUuid,
+          isClearSelection: true
+        })
       })
     },
 


### PR DESCRIPTION
if the search criteria field has no dependent fields the search is not activated.

### Before this changes:

https://user-images.githubusercontent.com/20288327/221963841-72c24294-191a-475f-a763-fb1e37eb96d8.mp4

### After this changes:

https://user-images.githubusercontent.com/20288327/221963895-79c9a344-3a52-4787-9e30-e50ca2c1c772.mp4


### Additional context:
fixes https://github.com/solop-develop/frontend-core/issues/889

