### PR TITLE
fix: Smart Browser search with query criteria field is empty and mandatory.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/browser/actions.js
+++ b/src/store/modules/ADempiere/dictionary/browser/actions.js
@@ -326,7 +326,7 @@ export default {
       fieldsList = getters.getStoredFieldsFromBrowser(containerUuid)
     }
 
-    let isChangedDisplayedWithValue = false
+    let fieldChangedDisplayedWithValue = false
 
     fieldsList.forEach(itemField => {
       const { columnName } = itemField
@@ -348,7 +348,7 @@ export default {
         attributeValue: isShowedFromUser
       })
 
-      if (!isChangedDisplayedWithValue) {
+      if (!fieldChangedDisplayedWithValue) {
         const value = rootGetters.getValueOfField({
           containerUuid,
           columnName
@@ -356,15 +356,16 @@ export default {
         // if isShowedFromUser was changed with value, the SmartBrowser
         // must send the parameters to update the search result
         if (!isEmptyValue(value)) {
-          isChangedDisplayedWithValue = true
+          fieldChangedDisplayedWithValue = itemField
         }
       }
     })
 
-    if (isChangedDisplayedWithValue) {
-      dispatch('getBrowserSearch', {
+    if (fieldChangedDisplayedWithValue) {
+      // dispatch('getBrowserSearch', {
+      dispatch('browserActionPerformed', {
         containerUuid,
-        isClearSelection: true
+        field: fieldChangedDisplayedWithValue
       })
     }
   },

--- a/src/utils/ADempiere/dictionary/browser.js
+++ b/src/utils/ADempiere/dictionary/browser.js
@@ -31,7 +31,7 @@ import { requestSaveBrowseCustomization } from '@/api/ADempiere/user-customizati
 
 // Utils and Helpers Methods
 import { isHiddenField } from '@/utils/ADempiere/references'
-import { showMessage, showNotification } from '@/utils/ADempiere/notification.js'
+import { showNotification } from '@/utils/ADempiere/notification.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { zoomIn } from '@/utils/ADempiere/coreUtils.js'
 
@@ -147,17 +147,6 @@ export const refreshBrowserSearh = {
   icon: 'el-icon-refresh',
   actionName: 'refreshRecords',
   refreshRecords: ({ containerUuid }) => {
-    const fieldsEmpty = store.getters.getBrowserFieldsEmptyMandatory({
-      containerUuid
-    })
-    if (!isEmptyValue(fieldsEmpty)) {
-      showMessage({
-        message: language.t('notifications.mandatoryFieldMissing') + fieldsEmpty,
-        type: 'info'
-      })
-      return
-    }
-
     // used to browser
     store.dispatch('getBrowserSearch', {
       containerUuid
@@ -363,9 +352,9 @@ export const containerManager = {
    * Is displayed field in panel single record
    */
   isDisplayedField,
-  isDisplayedDefault: ({ isMandatory, defaultValue }) => {
+  isDisplayedDefault: ({ isMandatory }) => {
     // add is showed from user
-    if (isMandatory || !isEmptyValue(defaultValue)) {
+    if (isMandatory) {
       return true
     }
     return false


### PR DESCRIPTION
### Before this changes:

https://user-images.githubusercontent.com/20288327/221966027-ea6c647e-e4b5-44e0-bdda-7d892d0d0faa.mp4



### After this changes:

https://user-images.githubusercontent.com/20288327/221966062-cc4f7974-2753-442a-9c8c-bcffe9b8f34b.mp4

### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/890

