### PR TITLE
fix: Process without record id.

### DIFF
--- a/src/store/modules/ADempiere/containerInfo/index.js
+++ b/src/store/modules/ADempiere/containerInfo/index.js
@@ -121,6 +121,12 @@ const containerInfo = {
       currentTab
     }) {
       commit('setContainerInfo', { currentRecord, currentTab })
+
+      commit('changeWindowAttribute', {
+        uuid: currentTab.parentUuid,
+        attributeName: 'currentTabUuid',
+        attributeValue: currentTab.uuid
+      })
     },
     fieldListInfo({ commit }, {
       info

--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -100,6 +100,12 @@ export default {
     return window.currentTabChild
   },
 
+  getCurrentTabUuid: (state, getters) => (windowUuid) => {
+    const window = getters.getStoredWindow(windowUuid)
+
+    return window.currentTabUuid
+  },
+
   getStoredFieldFromTab: (state, getters) => ({ windowUuid, tabUuid, columnName, fieldUuid }) => {
     return getters.getStoredFieldsFromTab(windowUuid, tabUuid)
       .find(field => {

--- a/src/views/ADempiere/Window/DocumentWindow.vue
+++ b/src/views/ADempiere/Window/DocumentWindow.vue
@@ -153,7 +153,7 @@ export default defineComponent({
     })
 
     const currentTabUuid = computed(() => {
-      return store.getters.getCurrentTab(props.windowMetadata.uuid).uuid
+      return store.getters.getCurrentTabUuid(props.windowMetadata.uuid)
     })
 
     const tableName = store.getters.getTableName(props.windowMetadata.uuid, currentTabUuid.value)

--- a/src/views/ADempiere/Window/Finances.vue
+++ b/src/views/ADempiere/Window/Finances.vue
@@ -155,7 +155,7 @@ export default defineComponent({
     })
 
     const currentTabUuid = computed(() => {
-      return store.getters.getCurrentTab(props.windowMetadata.uuid).uuid
+      return store.getters.getCurrentTabUuid(props.windowMetadata.uuid)
     })
 
     const styleFullScreen = computed(() => {

--- a/src/views/ADempiere/Window/GeneralLedger.vue
+++ b/src/views/ADempiere/Window/GeneralLedger.vue
@@ -155,7 +155,7 @@ export default defineComponent({
     })
 
     const currentTabUuid = computed(() => {
-      return store.getters.getCurrentTab(props.windowMetadata.uuid).uuid
+      return store.getters.getCurrentTabUuid(props.windowMetadata.uuid)
     })
 
     const styleFullScreen = computed(() => {

--- a/src/views/ADempiere/Window/MaterialsManagement.vue
+++ b/src/views/ADempiere/Window/MaterialsManagement.vue
@@ -152,7 +152,7 @@ export default defineComponent({
     })
 
     const currentTabUuid = computed(() => {
-      return store.getters.getCurrentTab(props.windowMetadata.uuid).uuid
+      return store.getters.getCurrentTabUuid(props.windowMetadata.uuid)
     })
 
     const styleFullScreen = computed(() => {

--- a/src/views/ADempiere/Window/MultiTabWindow.vue
+++ b/src/views/ADempiere/Window/MultiTabWindow.vue
@@ -145,7 +145,7 @@ export default defineComponent({
     })
 
     const currentTabUuid = computed(() => {
-      return store.getters.getCurrentTab(props.windowMetadata.uuid).uuid
+      return store.getters.getCurrentTabUuid(props.windowMetadata.uuid)
     })
 
     const styleFullScreen = computed(() => {


### PR DESCRIPTION
When is run process associated in two or more tabs on same windows, always takes the uuid of the first tab it is associated with.

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1014