### PR TITLE
Error: Order of the table columns in a `Smat Browse`.

### DIFF
--- a/src/views/ADempiere/Browser/index.vue
+++ b/src/views/ADempiere/Browser/index.vue
@@ -220,7 +220,11 @@ export default defineComponent({
     })
 
     const tableHeader = computed(() => {
-      return storedBrowser.value.fieldsList
+      const { fieldsList } = storedBrowser.value
+      const header = fieldsList.sort((itemA, itemB) => {
+        return itemA.sequence - itemB.sequence
+      })
+      return header
     })
 
     function generateBrowser(browser) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

Error Order of the Columns in a SB

#### Screenshot or Gif

![image](https://github.com/solop-develop/frontend-core/assets/45974454/d0242545-2b3a-4127-b1ce-6dbcb6bbef88)

![image](https://github.com/solop-develop/frontend-default-theme/assets/45974454/d95b9ed8-9c86-4880-bb10-61531e6eb56e)

#### Issues

Fixed #1026