### PR TITLE
fix: Callout context, return clear empty values.

### DIFF
--- a/src/store/modules/ADempiere/calloutManager.js
+++ b/src/store/modules/ADempiere/calloutManager.js
@@ -1,6 +1,6 @@
 /**
  * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
- * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Copyright (C) 2018-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
  * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,13 +24,13 @@ import { runCallOutRequest } from '@/api/ADempiere/window'
 // Constants
 import { ROW_ATTRIBUTES } from '@/utils/ADempiere/tableUtils'
 import { DISPLAY_COLUMN_PREFIX, UNIVERSALLY_UNIQUE_IDENTIFIER_COLUMN_SUFFIX } from '@/utils/ADempiere/dictionaryUtils'
-import { TABLE } from '@/utils/ADempiere/references'
 
 // Utils and Helper Methods
 import { isEmptyValue, isSameValues } from '@/utils/ADempiere/valueUtils'
 import { showMessage } from '@/utils/ADempiere/notification'
 import { convertObjectToKeyValue } from '@/utils/ADempiere/formatValue/iterableFormat'
 import { isNumber } from '@/utils/ADempiere/formatValue/numberFormat'
+import { isIntegerDisplayType } from '@/utils/ADempiere/references'
 
 const calloutManager = {
   actions: {
@@ -84,7 +84,7 @@ const calloutManager = {
               displayType = parentField.displayType
             }
           }
-          if (!isEmptyValue(displayType) && displayType === TABLE.id) {
+          if (!isEmptyValue(displayType) && isIntegerDisplayType(displayType)) {
             // AD_Language = 'en_US' and table
             if (!isNumber(value)) {
               valueType = 'STRING'

--- a/src/store/modules/ADempiere/persistence.js
+++ b/src/store/modules/ADempiere/persistence.js
@@ -126,6 +126,10 @@ const persistence = {
           columnName = field.columnName
         }
 
+        if (isEmptyValue(recordUuid)) {
+          recordUuid = getters.getUuidOfContainer(field.containerUuid)
+        }
+
         // TODO: Old value is not working
         let oldValue
         if (!isEmptyValue(currentRecord)) {
@@ -152,7 +156,7 @@ const persistence = {
           }
           commit('addChangeToPersistenceQueue', {
             containerUuid,
-            recordUuid: getters.getUuidOfContainer(field.containerUuid),
+            recordUuid,
             columnName: field.displayColumnName,
             oldValue: displayedValue,
             value: undefined
@@ -161,7 +165,7 @@ const persistence = {
 
         commit('addChangeToPersistenceQueue', {
           containerUuid,
-          recordUuid: getters.getUuidOfContainer(field.containerUuid),
+          recordUuid,
           columnName,
           oldValue,
           value

--- a/src/utils/ADempiere/references.js
+++ b/src/utils/ADempiere/references.js
@@ -1,6 +1,6 @@
 /**
  * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
- * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Copyright (C) 2018-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
  * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -355,6 +355,36 @@ export function isLookup(displayType) {
 // Some helper methods
 export function isSupportLookup(displayType) {
   return SUPPORTED_LOOKUPS.includes(displayType)
+}
+
+export const FIELDS_IDENTIFIER = [
+  ID.id,
+  TABLE.id,
+  TABLE_DIRECT.id,
+  SEARCH.id,
+  ACCOUNT_ELEMENT.id,
+  LOCATION_ADDRESS.id,
+  LOCATOR_WAREHOUSE.id,
+  PRODUCT_ATTRIBUTE.id,
+  RESOURCE_ASSIGNMENT.id
+]
+
+/**
+ * Is Identifier reference
+ * @param {Numner} displayType or reference to displayed
+ * @returns {Boolean}
+ */
+export function isIdentifier(displayType) {
+  return FIELDS_IDENTIFIER.includes(displayType)
+}
+
+/**
+ * Is Integer value to save by this reference to displayed
+ * @param {Numner} displayType or reference to displayed
+ * @returns {Boolean}
+ */
+export function isIntegerDisplayType(displayType) {
+  return FIELDS_IDENTIFIER.includes(displayType) || displayType === INTEGER.id
 }
 
 /**


### PR DESCRIPTION
If the column that triggers the callout is `C_BPartner_ID`, whose value is 10000, but it is sent in the context attributes `C_BPartner_ID = 5000`, in the return context it will still have the value 5000 when it should be 1000.

It also does not take into account the context that is emptied, which may be necessary for fields that depend on another for their value such as `C_BPartner_Location_ID`.

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/636
