### PR TITLE
fix: Refresh record after run process always.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -41,6 +41,7 @@ import {
   generateReportOfWindow,
   openBrowserAssociated,
   openSequenceTab,
+  refreshRecord,
   refreshRecords,
   recordAccess,
   undoChange
@@ -248,14 +249,14 @@ export default {
                 tableName,
                 recordUuid
               }).then(async processResponse => {
-                if (processResponse.isError) {
-                  return
-                }
+                // if (processResponse.isError) {
+                //   return
+                // }
 
-                // update records
-                await dispatch('getEntities', {
+                await refreshRecord.refreshRecord({
                   parentUuid: windowUuid,
-                  containerUuid: tabUuid
+                  containerUuid: tabAssociatedUuid,
+                  recordUuid
                 })
                 // update records and logics on child tabs
                 tabDefinition.childTabs.filter(tabItem => {

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -1,6 +1,6 @@
 /**
  * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
- * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Copyright (C) 2018-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
  * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -962,7 +962,7 @@ export const refreshRecord = {
       isLoaded: false,
       containerUuid
     })
-    getEntity({
+    return getEntity({
       tabUuid: containerUuid,
       recordId,
       recordUuid


### PR DESCRIPTION
When a process associated with the tab is executed, such as processing a document, it sometimes generates an error and changes the status of the document, but if it generates an error, the record is not being updated and the user is not aware of the value change.


#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1085