### PR TITLE
Fix isKey Field to send as selection value in processing

### DIFF
--- a/src/store/modules/ADempiere/browserManager.js
+++ b/src/store/modules/ADempiere/browserManager.js
@@ -463,7 +463,7 @@ const browserControl = {
       // reduce list
       const fieldsListSelection = fieldsList
         .filter(itemField => {
-          return itemField.isIdentifier || !isReadOnlyColumn(itemField)
+          return itemField.isKey || itemField.isIdentifier || !isReadOnlyColumn(itemField)
         })
         .map(itemField => {
           return {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

When the SB select was sent, it did not send the key field in the selected values

#### Steps to reproduce

1. Lauch a random SB
2. Observe that the key field is not being sent in the selectedvalues

#### Expected behavior

This pr includes a modification to include the key field in the selected values

