### PR TITLE
Fix: Movil, menu de acciones, maximo 5 acciones y mas opciones en el drawer

### DIFF
--- a/src/lang/ADempiere/en/actionMenu.js
+++ b/src/lang/ADempiere/en/actionMenu.js
@@ -51,7 +51,9 @@ const actionMenu = {
   // references
   delete: 'Delete',
   references: 'References',
-  withoutReferences: 'Without references for record'
+  withoutReferences: 'Without references for record',
+  menu: 'Menú the',
+  moreOptions: 'More Options'
 }
 
 export default actionMenu

--- a/src/lang/ADempiere/es/actionMenu.js
+++ b/src/lang/ADempiere/es/actionMenu.js
@@ -51,7 +51,9 @@ const actionMenu = {
   withoutRelations: 'Sin Relaciones',
   // references
   references: 'Referencias',
-  withoutReferences: 'Sin referencias para el registro'
+  withoutReferences: 'Sin referencias para el registro',
+  menu: 'Menú de',
+  moreOptions: 'Más Opciones'
 }
 
 export default actionMenu

--- a/src/store/modules/ADempiere/containerInfo/index.js
+++ b/src/store/modules/ADempiere/containerInfo/index.js
@@ -35,6 +35,7 @@ const containerInfo = {
     listRecordLogs: [],
     recordAttachment: [],
     showContainerInfo: false,
+    showMenuMobile: false,
     containerPanelInfo: {},
     fieldLogs: [],
     currentFieldList: {
@@ -53,6 +54,9 @@ const containerInfo = {
     },
     setShowLogs(state, show) {
       state.showContainerInfo = show
+    },
+    setShowMenuMobile(state, show) {
+      state.showMenuMobile = show
     },
     setContainerInfo(state, params) {
       state.containerPanelInfo = params
@@ -177,6 +181,9 @@ const containerInfo = {
     },
     getShowLogs: (state) => {
       return state.showContainerInfo
+    },
+    getShowMenuMobile: (state) => {
+      return state.showMenuMobile
     },
     getContainerInfo: (state) => {
       return state.containerPanelInfo


### PR DESCRIPTION
  ## **_Bug report / Feature_**
  Fix: Movil, menu de acciones, maximo 5 acciones y mas opciones en el drawer
  - [x] Movil, menu de acciones, maximo 5 acciones y mas opciones en el drawer
  
  ### **_Screenshot or Gif_**


https://github.com/solop-develop/frontend-default-theme/assets/45974454/94b17a95-b299-4366-ab7e-68ca390f35d4

### **_Issues_**

Fixed: https://github.com/solop-develop/frontend-core/issues/1151

