### PR TITLE
fix: Access tab without fields on minimalist view.

### DIFF
--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -185,6 +185,15 @@ export function evaluateDefaultFieldShowed({
     return true
   }
 
+  if (isParent) {
+    return true
+  }
+
+  const { isParentTab, linkColumnName, parentColumnName } = store.getters.getStoredTab(parentUuid, containerUuid)
+  if (!isParentTab && (linkColumnName === columnName || parentColumnName === columnName)) {
+    return true
+  }
+
   const isMandatoryGenerated = isMandatoryField({
     isKey, columnName, displayType, isMandatory, mandatoryLogic, isMandatoryFromLogic
   })
@@ -243,11 +252,21 @@ export function evaluateDefaultFieldShowed({
  * @param {boolean} isParent
  */
 export function evaluateDefaultColumnShowed({
+  parentUuid, containerUuid,
   isKey, isParent, columnName,
   defaultValue, displayType, isShowedTableFromUser,
   isMandatory, mandatoryLogic, isMandatoryFromLogic
 }) {
   if (String(defaultValue).startsWith('@SQL=')) {
+    return true
+  }
+
+  if (isParent) {
+    return true
+  }
+
+  const { isParentTab, linkColumnName, parentColumnName } = store.getters.getStoredTab(parentUuid, containerUuid)
+  if (!isParentTab && (linkColumnName === columnName || parentColumnName === columnName)) {
     return true
   }
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Screenshot or Gif

Before this changes:

https://github.com/solop-develop/frontend-core/assets/20288327/ae2a3508-fdf9-4872-bd88-b6408d7df60a

After this changes

https://github.com/solop-develop/frontend-core/assets/20288327/1c6ab970-c95a-47fe-a040-6a897f6c770e

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1175

