### PR TITLE
fix: Error with isSameSize method when any array is undefined.

### DIFF
--- a/src/utils/ADempiere/formatValue/iterableFormat.js
+++ b/src/utils/ADempiere/formatValue/iterableFormat.js
@@ -1,6 +1,6 @@
 /**
  * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
- * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Copyright (C) 2018-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
  * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -9,11 +9,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
@@ -93,7 +93,12 @@ export function isSameSize(arrayA, arrayB) {
   if (isEmptyValue(arrayA) && isEmptyValue(arrayB)) {
     return true
   }
-
+  if (isEmptyValue(arrayA)) {
+    return isEmptyValue(arrayB)
+  }
+  if (isEmptyValue(arrayB)) {
+    return isEmptyValue(arrayA)
+  }
   return arrayA.length === arrayB.length
 }
 


### PR DESCRIPTION

Error when `isSameSize(undefined, [1, 2])`.

```log
Uncaught TypeError: arrayA is undefined
```

Error when `isSameSize([1, 2], undefined)`.

```log
Uncaught TypeError: arrayB is undefined
```