### PR TITLE
fix: Edit read only parent record after select child record.

### DIFF
--- a/src/store/modules/ADempiere/fieldValue.js
+++ b/src/store/modules/ADempiere/fieldValue.js
@@ -1,6 +1,6 @@
 /**
  * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
- * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Copyright (C) 2018-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
  * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -107,8 +107,9 @@ const value = {
           if (isOverWriteParent) {
             Vue.set(state.field, keyParent, value)
           } else {
+            const parentValue = state.field[keyParent]
             // const parentValue = state[keyParent]
-            if (!isEmptyValue(value)) {
+            if (isEmptyValue(parentValue) && !isEmptyValue(value)) {
               // tab child no replace parent context with empty
               Vue.set(state.field, keyParent, value)
             }

--- a/src/store/modules/ADempiere/panel/actions.js
+++ b/src/store/modules/ADempiere/panel/actions.js
@@ -462,6 +462,10 @@ const actions = {
       }
     }
 
+    if (isEmptyValue(field.dependentFieldsList)) {
+      return
+    }
+
     // Iterate for change logic
     field.dependentFieldsList.map(async fieldDependentDefinition => {
       let containerName, containerUuid, columnName

--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -273,6 +273,7 @@ const windowManager = {
 
         const {
           name,
+          isParentTab,
           isHasTree,
           fieldsList,
           linkColumnName,
@@ -461,7 +462,8 @@ const windowManager = {
               dispatch('updateValuesOfContainer', {
                 parentUuid,
                 containerUuid,
-                attributes
+                attributes,
+                isOverWriteParent: isParentTab
               })
 
               // TODO: Evaluate seek record on container manager

--- a/src/views/ADempiere/Test/MultiTabWindow/index.vue
+++ b/src/views/ADempiere/Test/MultiTabWindow/index.vue
@@ -68,13 +68,16 @@ export default defineComponent({
           }
         }, () => {})
 
+        const tabDefinition = store.getters.getStoredTab(parentUuid, containerUuid)
+
         const attributes = convertObjectToKeyValue({
           object: row
         })
         store.dispatch('notifyPanelChange', {
           parentUuid,
           containerUuid,
-          attributes
+          attributes,
+          isOverWriteParent: tabDefinition.isParentTab
         })
       },
 


### PR DESCRIPTION
- Refresh all records when is table.
- Refresh childs records after process header document.
- Edit current document after process.
- Edit header document when select line record.

fixes https://github.com/solop-develop/frontend-core/issues/1299