### PR TITLE
feat: `Bank Statement Match` filter by bank statement id.

### DIFF
--- a/src/api/ADempiere/form/VBankStatementMatch.js
+++ b/src/api/ADempiere/form/VBankStatementMatch.js
@@ -95,6 +95,7 @@ export function requestSearchModesList({
 export function requestImportedBankMovements({
   matchMode,
   searchValue,
+  bankStatementId,
   bankAccountId,
   paymentAmountFrom,
   paymentAmountTo,
@@ -107,6 +108,7 @@ export function requestImportedBankMovements({
     params: {
       match_mode: matchMode,
       search_value: searchValue,
+      bank_statement_id: bankStatementId,
       bank_account_id: bankAccountId,
       payment_amount_from: paymentAmountFrom,
       payment_amount_to: paymentAmountTo,

--- a/src/store/modules/ADempiere/form/VBankStatementMatch.js
+++ b/src/store/modules/ADempiere/form/VBankStatementMatch.js
@@ -298,7 +298,7 @@ export default {
     /**
      * Get List Imported Bank Movements
      */
-    searchListImportedBankMovements({ commit, state }, {
+    searchListImportedBankMovements({ commit, state, getters }, {
       searchValue
     }) {
       return new Promise(resolve => {
@@ -307,10 +307,15 @@ export default {
         const businessPartnerId = state.businessPartner.id
         const dateFrom = state.transactionDate.from
         const dateTo = state.transactionDate.to
+        let bankStatementId = -1
+        if (!isEmptyValue(getters.getCurrentBankStatement)) {
+          bankStatementId = getters.getCurrentBankStatement.id
+        }
 
         requestImportedBankMovements({
           matchMode: matchMode,
           searchValue,
+          bankStatementId,
           bankAccountId,
           businessPartnerId,
           transactionDateFrom: dateFrom,


### PR DESCRIPTION
Filter Imported Bank Movements by bank statement id.

fixes https://github.com/solop-develop/frontend-core/issues/1323


