### PR TITLE
Remove suffix for API URL

### DIFF
--- a/build/start.sh
+++ b/build/start.sh
@@ -5,7 +5,7 @@ cd /usr/share/nginx/html/static/js
 
 
 # Set API Proxy connection
-find -name 'app.*.js' -exec sed -i "s|http://localhost:8085|$API_URL|g" {} \;
+find -name 'app.*.js' -exec sed -i "s|http://localhost:8085/api/adempiere/|$API_URL|g" {} \;
 
 # Set Task Manager connection
 find -name 'app.*.js' -exec sed -i "s|http://localhost:8080|$TASK_MANAGER_URL|g" {} \;


### PR DESCRIPTION
Just add complete URL for backend

Old value: `http://localhost:8085`
New value: `http://localhost:8085/api/adempiere/`