### PR TITLE
fix: Smart Browse search with range query criteria.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/browser/getters.js
+++ b/src/store/modules/ADempiere/dictionary/browser/getters.js
@@ -144,8 +144,8 @@ export default {
         containerUuid,
         columnName
       })
-      let valueTo
 
+      let valueTo
       if (fieldItem.isRange && !isNumberField(fieldItem.displayType)) {
         valueTo = rootGetters.getValueOfField({
           containerUuid,

--- a/src/store/modules/ADempiere/dictionary/browser/getters.js
+++ b/src/store/modules/ADempiere/dictionary/browser/getters.js
@@ -144,24 +144,26 @@ export default {
         containerUuid,
         columnName
       })
+      let valueTo
 
       if (fieldItem.isRange && !isNumberField(fieldItem.displayType)) {
-        const valueTo = rootGetters.getValueOfField({
+        valueTo = rootGetters.getValueOfField({
           containerUuid,
           columnName: fieldItem.columnNameTo
         })
-        if (!isEmptyValue(valueTo)) {
-          queryParams.push({
-            columnName: fieldItem.columnNameTo,
-            value: valueTo
-          })
-        }
+        // if (!isEmptyValue(valueTo)) {
+        //   queryParams.push({
+        //     columnName: fieldItem.columnNameTo,
+        //     value: valueTo
+        //   })
+        // }
       }
 
       if (!isEmptyValue(value)) {
         queryParams.push({
           columnName,
           value,
+          valueTo,
           operator
         })
       }


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Process Orders of selection` smart browse.
2. Displayed `Date Ordered` query criteria field.
3. Select any range.

#### Screenshot or Gif

https://github.com/solop-develop/frontend-core/assets/20288327/d0e71f96-1451-4212-8a69-f70c2b7834dc


#### Additional context
fixes https://github.com/solop-develop/adempiere-grpc-server/issues/515

