### PR TITLE
fix: Smart Browse omit query criteria `isInfoOnly`.

### DIFF
--- a/src/store/modules/ADempiere/browserManager.js
+++ b/src/store/modules/ADempiere/browserManager.js
@@ -119,6 +119,11 @@ const browserControl = {
           fieldsList,
           containerManager: containerManager
         }).then(() => {
+          if (field.isInfoOnly) {
+            // omit search
+            resolve()
+            return
+          }
           // Validate if a field is mandatory and visible
           dispatch('getBrowserSearch', {
             containerUuid,

--- a/src/store/modules/ADempiere/dictionary/browser/getters.js
+++ b/src/store/modules/ADempiere/dictionary/browser/getters.js
@@ -130,6 +130,9 @@ export default {
     const queryParams = []
 
     fieldsList.forEach(fieldItem => {
+      if (fieldItem.isInfoOnly) {
+        return false
+      }
       const { columnName, operator } = fieldItem
       const isMandatory = isMandatoryField(fieldItem)
       // evaluate displayed fields
@@ -188,6 +191,9 @@ export default {
     }
 
     const fieldsEmpty = fieldsList.filter(fieldItem => {
+      if (fieldItem.isInfoOnly) {
+        return false
+      }
       const isMandatory = isMandatoryField(fieldItem)
       const isDisplayed = isDisplayedField(fieldItem)
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce



#### Screenshot or Gif


https://github.com/solop-develop/frontend-core/assets/20288327/3ac66537-5fa7-403d-b32c-cde3bf40b21c

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1478

