### PR TITLE
feat: Deploy with sub path (public path to assets).

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,5 @@
+NODE_ENV = development
+
 # just a flag
 ENV = 'development'
 

--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,7 @@
+NODE_ENV = production
+
 # just a flag
 ENV = 'production'
 
 # base api
 VUE_APP_BASE_API = '/prod-api'
-

--- a/README.es.md
+++ b/README.es.md
@@ -102,6 +102,8 @@ docker-compose up
 
 ### Variables de entorno para la configuración
 
+ * `PUBLIC_PATH`: Tendrás que establecer publicPath si planeas desplegar tu sitio bajo una sub-ruta, por ejemplo GitHub Pages. Si planeas desplegar tu sitio en `https://adempiere-vue.github.io/bar/`, entonces publicPath debe establecerse en `/bar/`. En la mayoría de los casos, utilice `/`.
+ 
  * `API_URL`: Indica la dirección URL del servidor con el que se comunicará por defecto el cliente web [Proxy-Adempiere-Api](https://github.com/adempiere/proxy-adempiere-api), el valor por defecto es `http://localhost:8085/api/adempiere/`.
 
  * `TASK_MANAGER_URL`: Indica la dirección URL del API RESTFul para el mangejador de tareas [ADempiere-Business-Processors](https://github.com/adempiere/adempiere-business-processors) y [`dKron`](https://dkron.io/), el valor por defecto es `http://localhost:8085`.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ docker-compose up
 
 ### Environment variables for the configuration
 
+ * `PUBLIC_PATH`: You will need to set publicPath if you plan to deploy your site under a sub path, for example GitHub Pages. If you plan to deploy your site to `https://adempiere-vue.github.io/bar/`, then publicPath should be set to `/bar/`. In most cases please use `/`.
+
  * `API_URL`: It indicates the address of the server to which you will point the service [Proxy-Adempiere-Api](https://github.com/adempiere/proxy-adempiere-api), by default its value is `http://localhost:8085/api/adempiere/`.
 
  * `TASK_MANAGER_URL`: It indicates the address of the API RESTFul to task manager [ADempiere-Business-Processors](https://github.com/adempiere/adempiere-business-processors) and [`dKron`](https://dkron.io/), by default its value is `http://localhost:8080/v1`.

--- a/build/production-alpine.Dockerfile
+++ b/build/production-alpine.Dockerfile
@@ -1,11 +1,12 @@
-FROM nginx:1.25.0-alpine3.17
+FROM nginx:1.25.3-alpine3.18
 
 LABEL maintainer="Elsiosanches@gmail.com; EdwinBetanc0urt@outlook.com;" \
 	description="ADempiere-Vue."
 
 
 # Init ENV with default values
-ENV API_URL="http://localhost:8085/api/adempiere/" \
+ENV PUBLIC_PATH="/" \
+	API_URL="http://localhost:8085/api/adempiere/" \
 	TASK_MANAGER_URL="http://localhost:8080/v1" \
 	TZ="America/Caracas"
 

--- a/build/production.Dockerfile
+++ b/build/production.Dockerfile
@@ -1,11 +1,12 @@
-FROM nginx:1.25.0
+FROM nginx:1.25.3
 
 LABEL maintainer="Elsiosanches@gmail.com; EdwinBetanc0urt@outlook.com;" \
 	description="ADempiere-Vue."
 
 
 # Init ENV with default values
-ENV API_URL="http://localhost:8085/api/adempiere/" \
+ENV PUBLIC_PATH="/" \
+	API_URL="http://localhost:8085/api/adempiere/" \
 	TASK_MANAGER_URL="http://localhost:8080/v1" \
 	TZ="America/Caracas"
 

--- a/build/start.sh
+++ b/build/start.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Set Public Path to static assets *.html, *.css, *.img, *.js ("publicPath":"/")
+cd /usr/share/nginx/html
+find . -type f -exec sed -i "s|/base-public-path/|$PUBLIC_PATH|g" {} +
+# find -name 'app.*.js' -exec sed -i "s|/base-public-path/|$PUBLIC_PATH|g" {} \;
+
+
 # folder with dist app files
 cd /usr/share/nginx/html/static/js
 

--- a/config/default.json
+++ b/config/default.json
@@ -1,7 +1,8 @@
 {
   "server": {
     "host": "localhost",
-    "port": 9527
+    "port": 9527,
+    "publicPath": "/base-public-path/"
   },
   "adempiere": {
     "api": {

--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,7 @@
     <script>
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('<%= htmlWebpackPlugin.options.pwaPath %>sw.js').then(function(registration) {
+        // navigator.serviceWorker.register('<%= BASE_URL %>sw.js').then(function(registration) {
           // Registration Success
           console.log('[serviceWorker]: registration successful with scope: ', registration.scope)
         }).catch(function(err) {

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,7 +2,7 @@
 const path = require('path')
 // use fs to get certificates files
 // const fs = require('fs')
-// const config = require('./config/default.json')
+const config = require('./config/default.json')
 const defaultSettings = require('./src/settings.js')
 // const theme = config.theme
 // const themeComponents = theme + '/components'
@@ -18,6 +18,12 @@ const name = defaultSettings.title || 'Adempiere Vue' // page title
 // You can change the port by the following method:
 // port = 9527 npm run dev OR npm run dev --port = 9527
 const port = process.env.port || process.env.npm_config_port || 9527 // dev port
+
+let publicPathValue = config.server.publicPath
+if (process.env.NODE_ENV === 'development') {
+  publicPathValue = '/'
+}
+
 // All configuration item explanations can be find in https://cli.vuejs.org/config/
 module.exports = {
   /**
@@ -27,7 +33,7 @@ module.exports = {
    * In most cases please use '/' !!!
    * Detail: https://cli.vuejs.org/config/#publicpath
    */
-  publicPath: '/',
+  publicPath: publicPathValue,
   outputDir: 'dist',
   assetsDir: 'static',
   lintOnSave: process.env.NODE_ENV === 'development',


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

The `PUBLIC_PATH` environment variable is set to set the sub folder of the static assets.

 * `PUBLIC_PATH`: You will need to set publicPath if you plan to deploy your site under a sub path, for example GitHub Pages. If you plan to deploy your site to `https://adempiere-vue.github.io/bar/`, then publicPath should be set to `/bar/`. In most cases please use `/`.

