### PR TITLE
fix: Process/Report parameter send `IsInfoOnly`.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/process/getters.js
+++ b/src/store/modules/ADempiere/dictionary/process/getters.js
@@ -53,6 +53,9 @@ export default {
     }
 
     const fieldsEmpty = fieldsList.filter(fieldItem => {
+      if (fieldItem.isInfoOnly) {
+        return false
+      }
       const isMandatory = isMandatoryField(fieldItem)
       const isDisplayed = isDisplayedField(fieldItem)
 
@@ -100,6 +103,9 @@ export default {
     const processParameters = []
 
     fieldsList.forEach(fieldItem => {
+      if (fieldItem.isInfoOnly) {
+        return false
+      }
       const { columnName } = fieldItem
       const isMandatory = isMandatoryField(fieldItem)
       if (!isMandatory) {

--- a/src/store/modules/ADempiere/dictionary/report/getters.js
+++ b/src/store/modules/ADempiere/dictionary/report/getters.js
@@ -61,6 +61,9 @@ export default {
     }
 
     const fieldsEmpty = fieldsList.filter(fieldItem => {
+      if (fieldItem.isInfoOnly) {
+        return false
+      }
       const isMandatory = isMandatoryField(fieldItem)
       const isDisplayed = isDisplayedField(fieldItem)
 
@@ -108,6 +111,9 @@ export default {
     const reportParameters = []
 
     fieldsList.forEach(fieldItem => {
+      if (fieldItem.isInfoOnly) {
+        return false
+      }
       const { columnName } = fieldItem
       const isMandatory = isMandatoryField(fieldItem)
       if (!isMandatory) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

When run `Process` or `Report` this consider parameter as `IsInfoOnly` to send server.
