### PR TITLE
fix: Currency Rate `Currency` clean with default value.

### DIFF
--- a/src/components/ADempiere/PanelDefinition/StandardPanel.vue
+++ b/src/components/ADempiere/PanelDefinition/StandardPanel.vue
@@ -1,19 +1,19 @@
 <!--
- ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
- Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
- Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
+  ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+  Copyright (C) 2018-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+  Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- GNU General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
 
- You should have received a copy of the GNU General Public License
- along with this program. If not, see <https:www.gnu.org/licenses/>.
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <https:www.gnu.org/licenses/>.
 -->
 
 <template>
@@ -66,11 +66,11 @@ import { defineComponent, ref, computed, watch } from '@vue/composition-api'
 
 import store from '@/store'
 
-// components and mixins
+// Components and Mixins
 import FieldDefinition from '@/components/ADempiere/FieldDefinition/index.vue'
 import FilterFields from '@/components/ADempiere/FilterFields/index.vue'
 
-// utils and helper methods
+// Utils and Helper Methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 import { FOCUSABLE_FIELDS_LIST } from '@/utils/ADempiere/componentUtils'
 
@@ -159,9 +159,7 @@ export default defineComponent({
     })
 
     const recordUuid = computed(() => {
-      // TODO: Change query name 'action'
-      const { action } = root.$route.query
-      return action
+      return store.getters.getUuidOfContainer(props.containerUuid)
     })
 
     const shadowGroup = computed(() => {

--- a/src/store/modules/ADempiere/persistence.js
+++ b/src/store/modules/ADempiere/persistence.js
@@ -256,7 +256,7 @@ const persistence = {
                   return true
                 }
                 // prevent `PO.set_Value: Column not updateable`
-                if (!isEmptyValue(recordUuid) && !field.isUpdateable) {
+                if (!isEmptyValue(recordUuid) && recordUuid !== 'create-new' && !field.isUpdateable) {
                   return false
                 }
                 if (LOG_COLUMNS_NAME_LIST.includes(columnName)) {
@@ -269,7 +269,7 @@ const persistence = {
         }
 
         if (!isEmptyValue(attributesList)) {
-          if (!isEmptyValue(recordUuid)) {
+          if (!isEmptyValue(recordUuid) && recordUuid !== 'create-new') {
             // Update existing entity
             return updateEntity({
               tabUuid: containerUuid,
@@ -449,7 +449,11 @@ const persistence = {
       const changes = state.persistence[key]
 
       if (!isEmptyValue(changes)) {
-        return Object.values(changes)
+        const valuesList = Object.values(changes)
+        if (isEmptyValue(recordUuid) || recordUuid === 'create-new') {
+          return valuesList
+        }
+        return valuesList
           // only changes
           .filter(attribute => {
             const { value, oldValue } = attribute
@@ -475,7 +479,8 @@ const persistence = {
       const changes = state.persistence[key]
 
       if (!isEmptyValue(changes)) {
-        if (isEmptyValue(recordUuid)) {
+        const valuesList = Object.values(changes)
+        if (isEmptyValue(recordUuid) || recordUuid === 'create-new') {
           const defaultRow = rootGetters.getTabParsedDefaultValue({
             parentUuid,
             containerUuid,
@@ -483,7 +488,7 @@ const persistence = {
             formatToReturn: 'object'
           })
 
-          return Object.values(changes)
+          return valuesList
             // only changes with default value
             .filter(attribute => {
               const { value, columnName } = attribute
@@ -491,7 +496,7 @@ const persistence = {
             })
         }
 
-        return Object.values(changes)
+        return valuesList
           // only changes
           .filter(attribute => {
             const { value, oldValue } = attribute

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -244,6 +244,7 @@ export function evaluateDefaultFieldShowed({
     VALUE, DOCUMENT_NO, CURRENCY,
     'DateInvoiced', 'DateOrdered', 'DatePromised',
     'DateTrx', 'MovementDate', 'M_Product_ID', 'QtyEntered',
+    'ValidTo',
     // TODO: Remove this columns with fixes default value
     'UserLevel'
   ]

--- a/src/utils/ADempiere/formatValue/numberFormat.js
+++ b/src/utils/ADempiere/formatValue/numberFormat.js
@@ -41,7 +41,7 @@ export function isNumber(value) {
   if (isNaN(value)) {
     return false
   }
-  true
+  return true
 }
 
 /**


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Currency Rate` window.
2. Select `New`.
3. Clear `Currency` value (load with default value).
4. Select same default `Currency`.
5. Fill values.
6. Save

#### Screenshot or Gif
Before this changes

https://github.com/solop-develop/frontend-core/assets/20288327/a0394d28-bd82-47df-af2c-aa7df0022f04


After this changes

https://github.com/solop-develop/frontend-core/assets/20288327/dc70e902-140e-46b3-bdae-38d4295f5545



#### Additional context
When the default value loaded in the currency is cleared and the same currency is selected.

