### PR TITLE
fix: Advanced query with date.

### DIFF
--- a/src/store/modules/ADempiere/persistence.js
+++ b/src/store/modules/ADempiere/persistence.js
@@ -23,7 +23,9 @@ import language from '@/lang'
 // Constants
 import { LOG_COLUMNS_NAME_LIST, UUID } from '@/utils/ADempiere/constants/systemColumns'
 import { ROW_ATTRIBUTES } from '@/utils/ADempiere/tableUtils'
-import { DISPLAY_COLUMN_PREFIX, IDENTIFIER_COLUMN_SUFFIX } from '@/utils/ADempiere/dictionaryUtils'
+import {
+  DISPLAY_COLUMN_PREFIX, IDENTIFIER_COLUMN_SUFFIX, IS_ADVANCED_QUERY
+} from '@/utils/ADempiere/dictionaryUtils'
 import { BUTTON, IMAGE } from '@/utils/ADempiere/references'
 
 // API Request Methods
@@ -112,7 +114,7 @@ const persistence = {
   },
 
   actions: {
-    actionPerformed({ commit, getters, rootState, dispatch }, {
+    windowActionPerformed({ commit, getters, rootState, dispatch }, {
       field,
       columnName,
       recordUuid,
@@ -176,15 +178,17 @@ const persistence = {
         })
 
         // start callout on server
-        dispatch('startCallout', {
-          parentUuid,
-          containerUuid,
-          field,
-          callout: field.callout,
-          columnName,
-          value,
-          oldValue
-        })
+        if (!containerUuid.endsWith(IS_ADVANCED_QUERY)) {
+          dispatch('startCallout', {
+            parentUuid,
+            containerUuid,
+            field,
+            callout: field.callout,
+            columnName,
+            value,
+            oldValue
+          })
+        }
 
         const isAutosave = rootState.settings.autoSave
         if (isAutosave) {

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -1524,7 +1524,7 @@ export const containerManager = {
   },
 
   actionPerformed: ({ field, columnName, value }) => {
-    return store.dispatch('actionPerformed', {
+    return store.dispatch('windowActionPerformed', {
       field,
       columnName,
       value


### PR DESCRIPTION

https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/f02ddea0-7338-4c7b-828e-5b38679f2172




```log
===========> UserInterface.listTabEntities: org.postgresql.util.PSQLException: ERROR: function upper(timestamp without time zone) does not exist
  Hint: No function matches the given name and argument types. You might need to add explicit type casts.
  Position: 6242, SQL=SELECT COUNT(*)  FROM C_Order AS C_Order LEFT JOIN C_DocType AS C_DocTypeTarget_ID_C_DocType ON(C_DocTypeTarget_ID_C_DocType.C_DocType_ID = C_Order.C_DocTypeTarget_ID) LEFT JOIN C_DocType_Trl AS C_DocTypeTarget_ID_C_DocType_Trl ON(C_DocTypeTarget_ID_C_DocType_Trl.C_DocType_ID = C_DocTypeTarget_ID_C_DocType.C_DocType_ID AND C_DocTypeTarget_ID_C_DocType_Trl.AD_Language = 'es_MX') LEFT JOIN C_BPartner AS Bill_BPartner_ID_C_BPartner ON(Bill_BPartner_ID_C_BPartner.C_BPartner_ID = C_Order.Bill_BPartner_ID) LEFT JOIN C_BPartner_Location AS Bill_Location_ID_C_BPartner_Location ON(Bill_Location_ID_C_BPartner_Location.C_BPartner_Location_ID = C_Order.Bill_Location_ID) LEFT JOIN AD_User AS Bill_User_ID_AD_User ON(Bill_User_ID_AD_User.AD_User_ID = C_Order.Bill_User_ID) LEFT JOIN AD_Ref_List AS DeliveryRule_AD_Ref_List ON(DeliveryRule_AD_Ref_List.Value = C_Order.DeliveryRule AND DeliveryRule_AD_Ref_List.AD_Reference_ID = 151) LEFT JOIN AD_Ref_List_Trl AS DeliveryRule_AD_Ref_List_Trl ON(DeliveryRule_AD_Ref_List_Trl.AD_Ref_List_ID = DeliveryRule_AD_Ref_List.AD_Ref_List_ID AND DeliveryRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS PriorityRule_AD_Ref_List ON(PriorityRule_AD_Ref_List.Value = C_Order.PriorityRule AND PriorityRule_AD_Ref_List.AD_Reference_ID = 154) LEFT JOIN AD_Ref_List_Trl AS PriorityRule_AD_Ref_List_Trl ON(PriorityRule_AD_Ref_List_Trl.AD_Ref_List_ID = PriorityRule_AD_Ref_List.AD_Ref_List_ID AND PriorityRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN C_BPartner AS DropShip_BPartner_ID_C_BPartner ON(DropShip_BPartner_ID_C_BPartner.C_BPartner_ID = C_Order.DropShip_BPartner_ID) LEFT JOIN C_BPartner_Location AS DropShip_Location_ID_C_BPartner_Location ON(DropShip_Location_ID_C_BPartner_Location.C_BPartner_Location_ID = C_Order.DropShip_Location_ID) LEFT JOIN AD_User AS DropShip_User_ID_AD_User ON(DropShip_User_ID_AD_User.AD_User_ID = C_Order.DropShip_User_ID) LEFT JOIN AD_Ref_List AS DeliveryViaRule_AD_Ref_List ON(DeliveryViaRule_AD_Ref_List.Value = C_Order.DeliveryViaRule AND DeliveryViaRule_AD_Ref_List.AD_Reference_ID = 152) LEFT JOIN AD_Ref_List_Trl AS DeliveryViaRule_AD_Ref_List_Trl ON(DeliveryViaRule_AD_Ref_List_Trl.AD_Ref_List_ID = DeliveryViaRule_AD_Ref_List.AD_Ref_List_ID AND DeliveryViaRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS FreightCostRule_AD_Ref_List ON(FreightCostRule_AD_Ref_List.Value = C_Order.FreightCostRule AND FreightCostRule_AD_Ref_List.AD_Reference_ID = 153) LEFT JOIN AD_Ref_List_Trl AS FreightCostRule_AD_Ref_List_Trl ON(FreightCostRule_AD_Ref_List_Trl.AD_Ref_List_ID = FreightCostRule_AD_Ref_List.AD_Ref_List_ID AND FreightCostRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS InvoiceRule_AD_Ref_List ON(InvoiceRule_AD_Ref_List.Value = C_Order.InvoiceRule AND InvoiceRule_AD_Ref_List.AD_Reference_ID = 150) LEFT JOIN AD_Ref_List_Trl AS InvoiceRule_AD_Ref_List_Trl ON(InvoiceRule_AD_Ref_List_Trl.AD_Ref_List_ID = InvoiceRule_AD_Ref_List.AD_Ref_List_ID AND InvoiceRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_User AS SalesRep_ID_AD_User ON(SalesRep_ID_AD_User.AD_User_ID = C_Order.SalesRep_ID) LEFT JOIN C_Charge AS C_Charge_ID_C_Charge ON(C_Charge_ID_C_Charge.C_Charge_ID = C_Order.C_Charge_ID) LEFT JOIN C_Charge_Trl AS C_Charge_ID_C_Charge_Trl ON(C_Charge_ID_C_Charge_Trl.C_Charge_ID = C_Charge_ID_C_Charge.C_Charge_ID AND C_Charge_ID_C_Charge_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Org AS AD_OrgTrx_ID_AD_Org ON(AD_OrgTrx_ID_AD_Org.AD_Org_ID = C_Order.AD_OrgTrx_ID) LEFT JOIN C_ElementValue AS User1_ID_C_ElementValue ON(User1_ID_C_ElementValue.C_ElementValue_ID = C_Order.User1_ID) LEFT JOIN C_ElementValue_Trl AS User1_ID_C_ElementValue_Trl ON(User1_ID_C_ElementValue_Trl.C_ElementValue_ID = User1_ID_C_ElementValue.C_ElementValue_ID AND User1_ID_C_ElementValue_Trl.AD_Language = 'es_MX') LEFT JOIN C_ElementValue AS User2_ID_C_ElementValue ON(User2_ID_C_ElementValue.C_ElementValue_ID = C_Order.User2_ID) LEFT JOIN C_ElementValue_Trl AS User2_ID_C_ElementValue_Trl ON(User2_ID_C_ElementValue_Trl.C_ElementValue_ID = User2_ID_C_ElementValue.C_ElementValue_ID AND User2_ID_C_ElementValue_Trl.AD_Language = 'es_MX') LEFT JOIN C_ElementValue AS User3_ID_C_ElementValue ON(User3_ID_C_ElementValue.C_ElementValue_ID = C_Order.User3_ID) LEFT JOIN C_ElementValue_Trl AS User3_ID_C_ElementValue_Trl ON(User3_ID_C_ElementValue_Trl.C_ElementValue_ID = User3_ID_C_ElementValue.C_ElementValue_ID AND User3_ID_C_ElementValue_Trl.AD_Language = 'es_MX') LEFT JOIN W_Basket AS W_Basket_ID_W_Basket ON(W_Basket_ID_W_Basket.W_Basket_ID = C_Order.W_Basket_ID) LEFT JOIN C_ElementValue AS User4_ID_C_ElementValue ON(User4_ID_C_ElementValue.C_ElementValue_ID = C_Order.User4_ID) LEFT JOIN C_ElementValue_Trl AS User4_ID_C_ElementValue_Trl ON(User4_ID_C_ElementValue_Trl.C_ElementValue_ID = User4_ID_C_ElementValue.C_ElementValue_ID AND User4_ID_C_ElementValue_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS DocStatus_AD_Ref_List ON(DocStatus_AD_Ref_List.Value = C_Order.DocStatus AND DocStatus_AD_Ref_List.AD_Reference_ID = 131) LEFT JOIN AD_Ref_List_Trl AS DocStatus_AD_Ref_List_Trl ON(DocStatus_AD_Ref_List_Trl.AD_Ref_List_ID = DocStatus_AD_Ref_List.AD_Ref_List_ID AND DocStatus_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS DocAction_AD_Ref_List ON(DocAction_AD_Ref_List.Value = C_Order.DocAction AND DocAction_AD_Ref_List.AD_Reference_ID = 135) LEFT JOIN AD_Ref_List_Trl AS DocAction_AD_Ref_List_Trl ON(DocAction_AD_Ref_List_Trl.AD_Ref_List_ID = DocAction_AD_Ref_List.AD_Ref_List_ID AND DocAction_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_User AS AssignedSalesRep_ID_AD_User ON(AssignedSalesRep_ID_AD_User.AD_User_ID = C_Order.AssignedSalesRep_ID) WHERE C_Order.AD_Client_ID IN(0,11) AND C_Order.AD_Org_ID IN(11,1000003,12,1000004,1000000,1000001,1000002,0,50000,50002,50001,50004,50006,50005,50007) AND (C_Order.C_Order_ID IS NULL OR C_Order.C_Order_ID NOT IN ( SELECT Record_ID FROM AD_Private_Access WHERE AD_Table_ID = 259 AND AD_User_ID <> 101 AND IsActive = 'Y' )) AND C_Order.IsSOTrx='Y' AND EXISTS(SELECT 1 FROM C_DocType dt WHERE dt.C_DocType_ID = C_Order.C_DocTypeTarget_ID AND dt.DocBaseType = 'SOO' AND (dt.DocSubTypeSO IS NULL OR dt.DocSubTypeSO <> 'RM')) AND (UPPER(C_Order.DateOrdered)=UPPER(?)) [181]
org.adempiere.exceptions.DBException: org.postgresql.util.PSQLException: ERROR: function upper(timestamp without time zone) does not exist
  Hint: No function matches the given name and argument types. You might need to add explicit type casts.
  Position: 6242, SQL=SELECT COUNT(*)  FROM C_Order AS C_Order LEFT JOIN C_DocType AS C_DocTypeTarget_ID_C_DocType ON(C_DocTypeTarget_ID_C_DocType.C_DocType_ID = C_Order.C_DocTypeTarget_ID) LEFT JOIN C_DocType_Trl AS C_DocTypeTarget_ID_C_DocType_Trl ON(C_DocTypeTarget_ID_C_DocType_Trl.C_DocType_ID = C_DocTypeTarget_ID_C_DocType.C_DocType_ID AND C_DocTypeTarget_ID_C_DocType_Trl.AD_Language = 'es_MX') LEFT JOIN C_BPartner AS Bill_BPartner_ID_C_BPartner ON(Bill_BPartner_ID_C_BPartner.C_BPartner_ID = C_Order.Bill_BPartner_ID) LEFT JOIN C_BPartner_Location AS Bill_Location_ID_C_BPartner_Location ON(Bill_Location_ID_C_BPartner_Location.C_BPartner_Location_ID = C_Order.Bill_Location_ID) LEFT JOIN AD_User AS Bill_User_ID_AD_User ON(Bill_User_ID_AD_User.AD_User_ID = C_Order.Bill_User_ID) LEFT JOIN AD_Ref_List AS DeliveryRule_AD_Ref_List ON(DeliveryRule_AD_Ref_List.Value = C_Order.DeliveryRule AND DeliveryRule_AD_Ref_List.AD_Reference_ID = 151) LEFT JOIN AD_Ref_List_Trl AS DeliveryRule_AD_Ref_List_Trl ON(DeliveryRule_AD_Ref_List_Trl.AD_Ref_List_ID = DeliveryRule_AD_Ref_List.AD_Ref_List_ID AND DeliveryRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS PriorityRule_AD_Ref_List ON(PriorityRule_AD_Ref_List.Value = C_Order.PriorityRule AND PriorityRule_AD_Ref_List.AD_Reference_ID = 154) LEFT JOIN AD_Ref_List_Trl AS PriorityRule_AD_Ref_List_Trl ON(PriorityRule_AD_Ref_List_Trl.AD_Ref_List_ID = PriorityRule_AD_Ref_List.AD_Ref_List_ID AND PriorityRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN C_BPartner AS DropShip_BPartner_ID_C_BPartner ON(DropShip_BPartner_ID_C_BPartner.C_BPartner_ID = C_Order.DropShip_BPartner_ID) LEFT JOIN C_BPartner_Location AS DropShip_Location_ID_C_BPartner_Location ON(DropShip_Location_ID_C_BPartner_Location.C_BPartner_Location_ID = C_Order.DropShip_Location_ID) LEFT JOIN AD_User AS DropShip_User_ID_AD_User ON(DropShip_User_ID_AD_User.AD_User_ID = C_Order.DropShip_User_ID) LEFT JOIN AD_Ref_List AS DeliveryViaRule_AD_Ref_List ON(DeliveryViaRule_AD_Ref_List.Value = C_Order.DeliveryViaRule AND DeliveryViaRule_AD_Ref_List.AD_Reference_ID = 152) LEFT JOIN AD_Ref_List_Trl AS DeliveryViaRule_AD_Ref_List_Trl ON(DeliveryViaRule_AD_Ref_List_Trl.AD_Ref_List_ID = DeliveryViaRule_AD_Ref_List.AD_Ref_List_ID AND DeliveryViaRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS FreightCostRule_AD_Ref_List ON(FreightCostRule_AD_Ref_List.Value = C_Order.FreightCostRule AND FreightCostRule_AD_Ref_List.AD_Reference_ID = 153) LEFT JOIN AD_Ref_List_Trl AS FreightCostRule_AD_Ref_List_Trl ON(FreightCostRule_AD_Ref_List_Trl.AD_Ref_List_ID = FreightCostRule_AD_Ref_List.AD_Ref_List_ID AND FreightCostRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS InvoiceRule_AD_Ref_List ON(InvoiceRule_AD_Ref_List.Value = C_Order.InvoiceRule AND InvoiceRule_AD_Ref_List.AD_Reference_ID = 150) LEFT JOIN AD_Ref_List_Trl AS InvoiceRule_AD_Ref_List_Trl ON(InvoiceRule_AD_Ref_List_Trl.AD_Ref_List_ID = InvoiceRule_AD_Ref_List.AD_Ref_List_ID AND InvoiceRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_User AS SalesRep_ID_AD_User ON(SalesRep_ID_AD_User.AD_User_ID = C_Order.SalesRep_ID) LEFT JOIN C_Charge AS C_Charge_ID_C_Charge ON(C_Charge_ID_C_Charge.C_Charge_ID = C_Order.C_Charge_ID) LEFT JOIN C_Charge_Trl AS C_Charge_ID_C_Charge_Trl ON(C_Charge_ID_C_Charge_Trl.C_Charge_ID = C_Charge_ID_C_Charge.C_Charge_ID AND C_Charge_ID_C_Charge_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Org AS AD_OrgTrx_ID_AD_Org ON(AD_OrgTrx_ID_AD_Org.AD_Org_ID = C_Order.AD_OrgTrx_ID) LEFT JOIN C_ElementValue AS User1_ID_C_ElementValue ON(User1_ID_C_ElementValue.C_ElementValue_ID = C_Order.User1_ID) LEFT JOIN C_ElementValue_Trl AS User1_ID_C_ElementValue_Trl ON(User1_ID_C_ElementValue_Trl.C_ElementValue_ID = User1_ID_C_ElementValue.C_ElementValue_ID AND User1_ID_C_ElementValue_Trl.AD_Language = 'es_MX') LEFT JOIN C_ElementValue AS User2_ID_C_ElementValue ON(User2_ID_C_ElementValue.C_ElementValue_ID = C_Order.User2_ID) LEFT JOIN C_ElementValue_Trl AS User2_ID_C_ElementValue_Trl ON(User2_ID_C_ElementValue_Trl.C_ElementValue_ID = User2_ID_C_ElementValue.C_ElementValue_ID AND User2_ID_C_ElementValue_Trl.AD_Language = 'es_MX') LEFT JOIN C_ElementValue AS User3_ID_C_ElementValue ON(User3_ID_C_ElementValue.C_ElementValue_ID = C_Order.User3_ID) LEFT JOIN C_ElementValue_Trl AS User3_ID_C_ElementValue_Trl ON(User3_ID_C_ElementValue_Trl.C_ElementValue_ID = User3_ID_C_ElementValue.C_ElementValue_ID AND User3_ID_C_ElementValue_Trl.AD_Language = 'es_MX') LEFT JOIN W_Basket AS W_Basket_ID_W_Basket ON(W_Basket_ID_W_Basket.W_Basket_ID = C_Order.W_Basket_ID) LEFT JOIN C_ElementValue AS User4_ID_C_ElementValue ON(User4_ID_C_ElementValue.C_ElementValue_ID = C_Order.User4_ID) LEFT JOIN C_ElementValue_Trl AS User4_ID_C_ElementValue_Trl ON(User4_ID_C_ElementValue_Trl.C_ElementValue_ID = User4_ID_C_ElementValue.C_ElementValue_ID AND User4_ID_C_ElementValue_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS DocStatus_AD_Ref_List ON(DocStatus_AD_Ref_List.Value = C_Order.DocStatus AND DocStatus_AD_Ref_List.AD_Reference_ID = 131) LEFT JOIN AD_Ref_List_Trl AS DocStatus_AD_Ref_List_Trl ON(DocStatus_AD_Ref_List_Trl.AD_Ref_List_ID = DocStatus_AD_Ref_List.AD_Ref_List_ID AND DocStatus_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS DocAction_AD_Ref_List ON(DocAction_AD_Ref_List.Value = C_Order.DocAction AND DocAction_AD_Ref_List.AD_Reference_ID = 135) LEFT JOIN AD_Ref_List_Trl AS DocAction_AD_Ref_List_Trl ON(DocAction_AD_Ref_List_Trl.AD_Ref_List_ID = DocAction_AD_Ref_List.AD_Ref_List_ID AND DocAction_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_User AS AssignedSalesRep_ID_AD_User ON(AssignedSalesRep_ID_AD_User.AD_User_ID = C_Order.AssignedSalesRep_ID) WHERE C_Order.AD_Client_ID IN(0,11) AND C_Order.AD_Org_ID IN(11,1000003,12,1000004,1000000,1000001,1000002,0,50000,50002,50001,50004,50006,50005,50007) AND (C_Order.C_Order_ID IS NULL OR C_Order.C_Order_ID NOT IN ( SELECT Record_ID FROM AD_Private_Access WHERE AD_Table_ID = 259 AND AD_User_ID <> 101 AND IsActive = 'Y' )) AND C_Order.IsSOTrx='Y' AND EXISTS(SELECT 1 FROM C_DocType dt WHERE dt.C_DocType_ID = C_Order.C_DocTypeTarget_ID AND dt.DocBaseType = 'SOO' AND (dt.DocSubTypeSO IS NULL OR dt.DocSubTypeSO <> 'RM')) AND (UPPER(C_Order.DateOrdered)=UPPER(?))
        at org.compiere.util.DB.getSQLValueEx(DB.java:1330)
        at org.compiere.util.DB.getSQLValueEx(DB.java:1350)
        at org.spin.base.db.CountUtil.countRecords(CountUtil.java:81)
        at org.spin.base.db.CountUtil.countRecords(CountUtil.java:40)
        at org.spin.grpc.service.UserInterface.listTabEntities(UserInterface.java:809)
        at org.spin.grpc.service.UserInterface.listTabEntities(UserInterface.java:691)
        at org.spin.backend.grpc.user_interface.UserInterfaceGrpc$MethodHandlers.invoke(UserInterfaceGrpc.java:2200)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:351)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:860)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.postgresql.util.PSQLException: ERROR: function upper(timestamp without time zone) does not exist
  Hint: No function matches the given name and argument types. You might need to add explicit type casts.
  Position: 6242
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2675)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2365)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:355)
        at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:490)
        at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:408)
        at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:166)
        at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:118)
        at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)
        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)
        at jdk.internal.reflect.GeneratedMethodAccessor1.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.compiere.db.StatementProxy.invoke(StatementProxy.java:100)
        at com.sun.proxy.$Proxy4.executeQuery(Unknown Source)
        at org.compiere.util.DB.getSQLValueEx(DB.java:1322)
        ... 18 more
```

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1677
