### PR TITLE
fix: Default empty charge.

### DIFF
--- a/src/api/ADempiere/form/VAllocation.ts
+++ b/src/api/ADempiere/form/VAllocation.ts
@@ -188,7 +188,7 @@ export function requestListTransactionOrganizations({
 // process
 export function requestProcess({
   date,
-  chargeId = null,
+  chargeId = -1,
   currencyId,
   description,
   totalDifference,


### PR DESCRIPTION
```
charge_id: invalid value "" for type TYPE_INT32
```

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1718

