### PR TITLE
fix: Validate mime type on field `Image`.

### DIFF
--- a/src/api/ADempiere/file-management/resource-reference.ts
+++ b/src/api/ADempiere/file-management/resource-reference.ts
@@ -20,7 +20,9 @@
 import { request } from '@/utils/ADempiere/request'
 
 // Constants
-import { RESOURCE_TYPE_ATTACHMENT } from '@/utils/ADempiere/resource'
+import {
+  RESOURCE_TYPE_ATTACHMENT, RESOURCE_TYPE_FILE, RESOURCE_TYPE_IMAGE
+} from '@/utils/ADempiere/resource'
 
 // Utils and Helper Methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
@@ -44,8 +46,14 @@ export function requestSetResourceReference({
   fileName,
   fileSize
 }) {
+  let path = `/file-management/references/attachment/${tableName}/${recordId}`
+  if (resourceType == RESOURCE_TYPE_IMAGE) {
+    path = `/file-management/references/image/${id}`
+  } else if (resourceType == RESOURCE_TYPE_FILE) {
+    path = `/file-management/references/archive/${id}`
+  }
   return request({
-    url: `/file-management/references/attachment/${tableName}/${recordId}`,
+    url: path,
     method: 'put',
     data: {
       // parent values (attachment, image, archive)

--- a/src/api/ADempiere/file-management/resource-reference.ts
+++ b/src/api/ADempiere/file-management/resource-reference.ts
@@ -47,9 +47,9 @@ export function requestSetResourceReference({
   fileSize
 }) {
   let path = `/file-management/references/attachment/${tableName}/${recordId}`
-  if (resourceType == RESOURCE_TYPE_IMAGE) {
+  if (resourceType === RESOURCE_TYPE_IMAGE) {
     path = `/file-management/references/image/${id}`
-  } else if (resourceType == RESOURCE_TYPE_FILE) {
+  } else if (resourceType === RESOURCE_TYPE_FILE) {
     path = `/file-management/references/archive/${id}`
   }
   return request({

--- a/src/components/ADempiere/FieldDefinition/FieldImage.vue
+++ b/src/components/ADempiere/FieldDefinition/FieldImage.vue
@@ -102,6 +102,7 @@
             class="upload-button"
             name="file"
             :show-file-list="false"
+            :accept="MIME_TYPE_IMAGE"
             :multiple="false"
             :before-upload="isValidUploadHandler"
             :on-success="loadedSucess"
@@ -142,6 +143,7 @@
       :headers="additionalHeaders"
       drag
       name="file"
+      :accept="MIME_TYPE_IMAGE"
       :show-file-list="false"
       :multiple="false"
       :before-upload="isValidUploadHandler"
@@ -165,6 +167,7 @@ import FileInfo from '@/components/ADempiere/PanelInfo/Component/AttachmentManag
 // Constants
 import { config } from '@/utils/ADempiere/config'
 import { BEARER_TYPE } from '@/utils/auth'
+import { MIME_TYPE_IMAGE } from '@/utils/ADempiere/resource/image.ts'
 import { UUID_PATTERN } from '@/utils/ADempiere/recordUtil'
 import { RESOURCE_TYPE_IMAGE } from '@/utils/ADempiere/resource'
 
@@ -202,10 +205,10 @@ export default {
 
   data() {
     return {
-      endPointUploadResource: config.adempiere.api.url + 'user-interface/component/resource/save-attachment',
       additionalData: {},
       fileResource: {},
       imageSourceSmall: '',
+      MIME_TYPE_IMAGE,
       isLoadImage: false,
       valuesImage: [{
         identifier: 'undefined',
@@ -251,6 +254,13 @@ export default {
     //   console.log(blobImage)
     //   return blobImage.href
     // },
+    endPointUploadResource() {
+      let resourceId = this.value
+      if (isEmptyValue(resourceId)) {
+        resourceId = -1
+      }
+      return config.adempiere.resource.url + '/resources/' + resourceId
+    },
     imageSourceLarge() {
       const displayedAlt = this.displayedValue
       if (isEmptyValue(displayedAlt)) {
@@ -320,7 +330,7 @@ export default {
         }
         requestSetResourceReference({
           resourceType: RESOURCE_TYPE_IMAGE,
-          resourceId: this.value,
+          id: this.value || -1,
           fileName: file.name,
           fileSize: file.size
         }).then(response => {
@@ -331,8 +341,8 @@ export default {
 
           this.fileResource = response
           this.additionalData = {
-            resource_uuid: response.uuid,
-            file_name: response.file_name
+            id: response.id
+            // file_name: response.file_name
           }
 
           this.value = response.resource_id

--- a/src/utils/ADempiere/resource/image.ts
+++ b/src/utils/ADempiere/resource/image.ts
@@ -1,0 +1,19 @@
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2018-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export const MIME_TYPE_IMAGE = 'image/*'


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

When select a file to upload on field image type, this allow any file type.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
