### PR TITLE
fix: Cast correct parameter value by display type.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/process/getters.js
+++ b/src/store/modules/ADempiere/dictionary/process/getters.js
@@ -16,6 +16,9 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+// Constants
+import { FIELDS_DATE, FIELDS_DECIMALS } from '@/utils/ADempiere/references.js'
+
 // Utils and Helper Methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 import { isDisplayedField, isMandatoryField } from '@/utils/ADempiere/dictionary/process.js'
@@ -106,7 +109,7 @@ export default {
       if (fieldItem.isInfoOnly) {
         return false
       }
-      const { columnName } = fieldItem
+      const { columnName, displayType } = fieldItem
       const isMandatory = isMandatoryField(fieldItem)
       if (!isMandatory) {
         // evaluate displayed fields
@@ -120,6 +123,9 @@ export default {
         columnName
       })
 
+      const isDateField = FIELDS_DATE.includes(displayType)
+      const isDecimalField = FIELDS_DECIMALS.includes(displayType)
+
       if (fieldItem.isRange && !isNumberField(fieldItem.displayType)) {
         const valueTo = rootGetters.getValueOfField({
           containerUuid,
@@ -131,6 +137,17 @@ export default {
           //   value: valueTo
           // })
           processParameters[fieldItem.columnNameTo] = valueTo
+          if (isDateField) {
+            processParameters[columnName] = {
+              type: 'date',
+              value: valueTo
+            }
+          } else if (isDecimalField) {
+            processParameters[columnName] = {
+              type: 'decimal',
+              value: valueTo
+            }
+          }
         }
       }
 
@@ -140,6 +157,17 @@ export default {
         //   value
         // })
         processParameters[columnName] = value
+        if (isDateField) {
+          processParameters[columnName] = {
+            type: 'date',
+            value: value
+          }
+        } else if (isDecimalField) {
+          processParameters[columnName] = {
+            type: 'decimal',
+            value: value
+          }
+        }
       }
     })
 

--- a/src/store/modules/ADempiere/dictionary/report/getters.js
+++ b/src/store/modules/ADempiere/dictionary/report/getters.js
@@ -16,6 +16,9 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+// Constants
+import { FIELDS_DATE, FIELDS_DECIMALS } from '@/utils/ADempiere/references.js'
+
 // Utils and Helper Methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { isDisplayedField, isMandatoryField } from '@/utils/ADempiere/dictionary/process.js'
@@ -117,7 +120,7 @@ export default {
       if (fieldItem.isInfoOnly) {
         return false
       }
-      const { columnName } = fieldItem
+      const { columnName, displayType } = fieldItem
       const isMandatory = isMandatoryField(fieldItem)
       if (!isMandatory) {
         // evaluate displayed fields
@@ -131,6 +134,9 @@ export default {
         columnName
       })
 
+      const isDateField = FIELDS_DATE.includes(displayType)
+      const isDecimalField = FIELDS_DECIMALS.includes(displayType)
+
       if (fieldItem.isRange && !isNumberField(fieldItem.displayType)) {
         const valueTo = rootGetters.getValueOfField({
           containerUuid: uuid,
@@ -142,6 +148,17 @@ export default {
           //   value: valueTo
           // })
           reportParameters[fieldItem.columnNameTo] = valueTo
+          if (isDateField) {
+            reportParameters[columnName] = {
+              type: 'date',
+              value: valueTo
+            }
+          } else if (isDecimalField) {
+            reportParameters[columnName] = {
+              type: 'decimal',
+              value: valueTo
+            }
+          }
         }
       }
 
@@ -151,6 +168,17 @@ export default {
         //   value
         // })
         reportParameters[columnName] = value
+        if (isDateField) {
+          reportParameters[columnName] = {
+            type: 'date',
+            value: value
+          }
+        } else if (isDecimalField) {
+          reportParameters[columnName] = {
+            type: 'decimal',
+            value: value
+          }
+        }
       }
     })
 


### PR DESCRIPTION
When send string date on parameter set null on process info as it expects a timestamp.


#### Before this changes
```bash
curl 'http://0.0.0.0/api/report-management/report/2000038' \
  -X POST \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIyMDE3ODI2IiwiQURfQ2xpZW50X0lEIjoxMSwiQURfT3JnX0lEIjo1MDAwMSwiQURfUm9sZV9JRCI6MTAyLCJBRF9Vc2VyX0lEIjoxMDEsIk1fV2FyZWhvdXNlX0lEIjo1MDAwMiwiQURfTGFuZ3VhZ2UiOiJlbl9VUyIsImlhdCI6MTcwNzUwNjY3MywiZXhwIjoxNzA3NTkzMDczfQ.N329cciSjV0UWKWTUugk8xMlR8cUpxhYz6r5ZCvcaWo' \
  --data-raw '{"parameters":{"IsSOTrx":true,"DateTo":"2024-02-09T13:20:06.000Z","report_type":"pdf"}'
```

data raw:
```json
{
  "parameters":{
    "IsSOTrx":true,
    "DateTo":"2024-02-09T13:20:06.000Z"
  },
  "report_type":"pdf"
}
```
The `DateTo` is string data type.

#### After this changes

```bash
curl 'http://0.0.0.0/api/report-management/report/2000038' \
  -X POST \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIyMDE3ODI2IiwiQURfQ2xpZW50X0lEIjoxMSwiQURfT3JnX0lEIjo1MDAwMSwiQURfUm9sZV9JRCI6MTAyLCJBRF9Vc2VyX0lEIjoxMDEsIk1fV2FyZWhvdXNlX0lEIjo1MDAwMiwiQURfTGFuZ3VhZ2UiOiJlbl9VUyIsImlhdCI6MTcwNzUwNjY3MywiZXhwIjoxNzA3NTkzMDczfQ.N329cciSjV0UWKWTUugk8xMlR8cUpxhYz6r5ZCvcaWo' \
  --data-raw '{"parameters":{"IsSOTrx":true,"DateTo":{"type":"date","value":"2024-02-09T13:20:06.000Z"}},"report_type":"pdf"}'
```

data raw:
```json
{
  "parameters":{
    "IsSOTrx":true,
    "DateTo":{
      "type":"date",
      "value":"2024-02-09T13:20:06.000Z"
    }
  },
  "report_type":"pdf"
}
```

The `DateTo` is struct data type and specifies the `date` type.

#### Additional context
fixes https://github.com/solop-develop/adempiere-grpc-server/issues/683