### PR TITLE
fix: Rename `Control Panel` to `Graphics` into window info.

### DIFF
--- a/src/lang/ADempiere/en/index.js
+++ b/src/lang/ADempiere/en/index.js
@@ -117,7 +117,7 @@ export default {
       link: 'Go to Procces Logs'
     },
     resetCache: 'Cache Reset',
-    dashboard: 'Dashboard',
+    dashboard: 'Graphics',
     github: 'Github',
     logOut: 'Log Out',
     profile: 'Profile',

--- a/src/lang/ADempiere/es/index.js
+++ b/src/lang/ADempiere/es/index.js
@@ -119,7 +119,7 @@ export default {
     },
     resetCache: 'Reiniciar Cache',
     logOut: 'Salir',
-    dashboard: 'Panel de control',
+    dashboard: 'Gráficos',
     github: 'Github',
     theme: 'Tema',
     size: 'Tamaño global',


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
change of translation of the control panel option to graphics
#### Steps to reproduce

1. [Iniciar sesión con el rol "GardenWorld Admin"]
2. [Ir a la ventana de productos]
3. [Abrir la panel lateral]

#### Screenshot or Gif
![image](https://github.com/solop-develop/frontend-core/assets/78000356/7a927765-49fe-44e9-9896-1577d8cca87a)

![image](https://github.com/solop-develop/frontend-core/assets/78000356/40d4b62f-126e-43b4-9511-2b34e55f7d11)


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/2006
