### PR TITLE
fix: Side panel to profile

### DIFF
--- a/src/layout/components/Settings/index.vue
+++ b/src/layout/components/Settings/index.vue
@@ -2,66 +2,70 @@
   <div class="drawer-container">
     <!-- <div> -->
     <el-form label-position="top" :inline="true">
-      <el-form-item
-        :label="$t('page.settings.theme')"
-        class="drawer-title"
-      >
-        <theme-picker @change="themeChange" />
-      </el-form-item>
-      <el-form-item
-        :label="$t('page.settings.fixedHeader')"
-        class="drawer-title"
-      >
-        <el-switch v-model="fixedHeader" />
-      </el-form-item>
-      <el-form-item
-        :label="$t('page.settings.tagsView')"
-        class="drawer-title"
-      >
-        <el-switch v-model="tagsView" />
-      </el-form-item>
-      <el-form-item
-        :label="$t('page.settings.fixedHeader')"
-        class="drawer-title"
-      >
-        <el-switch v-model="showNavar" />
-      </el-form-item>
-      <el-form-item
-        :label="$t('page.settings.showContextMenu')"
-        class="drawer-title"
-      >
-        <el-switch v-model="showContextMenu" />
-      </el-form-item>
-      <el-form-item
-        :label="$t('page.settings.isShowTitle')"
-        class="drawer-title"
-      >
-        <el-switch v-model="isShowTitleForm" />
-      </el-form-item>
-      <el-form-item
-        :label="$t('page.settings.isShowMenu')"
-        class="drawer-title"
-      >
-        <el-switch v-model="showMenu" />
-      </el-form-item>
-      <el-form-item
-        :label="$t('page.settings.sidebarLogo')"
-        class="drawer-title"
-      >
-        <el-switch v-model="sidebarLogo" />
-      </el-form-item>
-      <el-form-item
-        :label="$t('page.settings.autoSave')"
-        class="drawer-title"
-      >
-        <el-switch v-model="showAutoSave" />
-      </el-form-item>
-      <el-form-item
-        :label="$t('page.settings.fullGridMode')"
-        class="drawer-title"
-      >
-        <el-switch v-model="showFullGridMode" />
-      </el-form-item>
+      <div>
+        <el-form-item
+          :label="$t('page.settings.theme')"
+          class="drawer-title"
+        >
+          <theme-picker @change="themeChange" />
+        </el-form-item>
+        <el-form-item
+          :label="$t('page.settings.fixedHeader')"
+          class="drawer-title"
+        >
+          <el-switch v-model="fixedHeader" />
+        </el-form-item>
+        <el-form-item
+          :label="$t('page.settings.tagsView')"
+          class="drawer-title"
+        >
+          <el-switch v-model="tagsView" />
+        </el-form-item>
+        <el-form-item
+          :label="$t('page.settings.fixedHeader')"
+          class="drawer-title"
+        >
+          <el-switch v-model="showNavar" />
+        </el-form-item>
+        <el-form-item
+          :label="$t('page.settings.showContextMenu')"
+          class="drawer-title"
+        >
+          <el-switch v-model="showContextMenu" />
+        </el-form-item>
+      </div>
+      <div>
+        <el-form-item
+          :label="$t('page.settings.isShowTitle')"
+          class="drawer-title"
+        >
+          <el-switch v-model="isShowTitleForm" />
+        </el-form-item>
+        <el-form-item
+          :label="$t('page.settings.isShowMenu')"
+          class="drawer-title"
+        >
+          <el-switch v-model="showMenu" />
+        </el-form-item>
+        <el-form-item
+          :label="$t('page.settings.sidebarLogo')"
+          class="drawer-title"
+        >
+          <el-switch v-model="sidebarLogo" />
+        </el-form-item>
+        <el-form-item
+          :label="$t('page.settings.autoSave')"
+          class="drawer-title"
+        >
+          <el-switch v-model="showAutoSave" />
+        </el-form-item>
+        <el-form-item
+          :label="$t('page.settings.fullGridMode')"
+          class="drawer-title"
+        >
+          <el-switch v-model="showFullGridMode" />
+        </el-form-item>
+      </div>
       <el-form-item
         :label="$t('page.settings.mainDashboardCard')"
         class="drawer-title"
@@ -89,6 +93,44 @@
             :key="item.id"
             :label="item.name"
             :value="item.id"
+          />
+        </el-select>
+      </el-form-item>
+      <el-form-item
+        :label="$t('page.settings.rightPanelContent')"
+        class="drawer-title"
+      >
+        <el-select
+          v-model="panelLeft"
+          multiple
+          size="mini"
+          collapse-tags
+          style="margin-left: 20px;"
+        >
+          <el-option
+            v-for="item in optionsPanelLeft"
+            :key="item.value"
+            :label="item.label"
+            :value="item.value"
+          />
+        </el-select>
+      </el-form-item>
+      <el-form-item
+        :label="$t('page.settings.leftPanelContent')"
+        class="drawer-title"
+      >
+        <el-select
+          v-model="panelRight"
+          multiple
+          collapse-tags
+          size="mini"
+          style="margin-left: 20px;"
+        >
+          <el-option
+            v-for="item in optionsPanelRight"
+            :key="item.value"
+            :label="item.label"
+            :value="item.value"
           />
         </el-select>
       </el-form-item>
@@ -373,9 +415,74 @@ export default {
       store.commit('changeShowTitleForm', !isShowTitleForm.value)
     }
 
+    const panelLeft = computed({
+      // getter
+      get() {
+        return store.getters['settings/getPanelLeft']
+      },
+      // setter
+      set(newValue) {
+        // Note: we are using destructuring assignment syntax here.
+        store.dispatch('settings/changeSetting', {
+          key: 'panelLeft',
+          value: newValue
+        })
+      }
+    })
+    const optionsPanelLeft = ref([
+      {
+        value: 'PC',
+        label: 'Graficos Tipos Pie'
+      },
+      {
+        value: 'userfavorites',
+        label: 'Panel de Favoritos'
+      },
+      // {
+      //   value: 'todo',
+      //   label: 'Panel de Por Hacer'
+      // },
+      {
+        value: 'recentItems',
+        label: 'Panel de Últimos documentos'
+      }
+    ])
+    const panelRight = computed({
+      // getter
+      get() {
+        return store.getters['settings/getPanelRight']
+      },
+      // setter
+      set(newValue) {
+        // Note: we are using destructuring assignment syntax here.
+        store.dispatch('settings/changeSetting', {
+          key: 'panelRight',
+          value: newValue
+        })
+      }
+    })
+    const optionsPanelRight = ref([
+      {
+        value: 'BC',
+        label: 'Graficos Tipos Barra'
+      },
+      {
+        value: 'LC',
+        label: 'Graficos Tipos Line'
+      },
+      {
+        value: 'notices',
+        label: 'Panel de Avisos'
+      }
+    ])
     return {
       // data
       activeName,
+      // Ref
+      panelLeft,
+      panelRight,
+      optionsPanelLeft,
+      optionsPanelRight,
       // Computed
       lang,
       colNum,

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -18,7 +18,7 @@ const state = {
   autoSave: !isEmptyValue(localStorage.getItem('autoSave')) ? convertStringToBoolean(localStorage.getItem('autoSave')) : autoSave,
   fullGridMode: !isEmptyValue(localStorage.getItem('fullGridMode')) ? convertStringToBoolean(localStorage.getItem('fullGridMode')) : fullGridMode,
   showMenu: true,
-  panelLeft: ['PC', 'userfavorites', 'todo', 'recentItems'],
+  panelLeft: ['PC', 'userfavorites', 'recentItems'],
   panelRight: ['BC', 'LC', 'notices']
 }
 

--- a/src/views/dashboard/admin/index.vue
+++ b/src/views/dashboard/admin/index.vue
@@ -84,7 +84,7 @@
         </template>
       </el-col>
     </el-row>
-    <page-style-settings />
+    <!-- <page-style-settings /> -->
   </div>
 </template>
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
hide side panel, move side panel options to profile settings and view tasks to do
#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif

before

https://github.com/solop-develop/frontend-core/assets/78000356/298d5810-5c46-42c5-a014-a370cd037e53


after


https://github.com/solop-develop/frontend-core/assets/78000356/10fc4208-a89c-4eb3-a363-cf6a6bcd8ef2



#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
fixed: https://github.com/solop-develop/frontend-core/issues/2100 
fixed: https://github.com/solop-develop/frontend-core/issues/2101 
fixed: https://github.com/solop-develop/frontend-core/issues/2102
fixes https://github.com/solop-develop/frontend-core/issues/1491
