### PR TITLE
fix: Enable text `Payment Allocation` form

### DIFF
--- a/src/components/ADempiere/FormDefinition/VAllocation/components/Payments.vue
+++ b/src/components/ADempiere/FormDefinition/VAllocation/components/Payments.vue
@@ -351,7 +351,10 @@ export default defineComponent({
       },
       // setter
       set(value) {
-        store.commit('setProcess', value)
+        store.commit('setProcess', {
+          attribute: 'description',
+          value
+        })
       }
     })
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
enable text field
#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif


https://github.com/solop-develop/frontend-core/assets/78000356/e93f2445-2622-44a5-a88d-c9dc3991a7da


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
fixed: https://github.com/solop-develop/frontend-core/issues/2076