### PR TITLE
bugfix: Comment size

### DIFF
--- a/src/components/ADempiere/Form/Issues/component/Comment.vue
+++ b/src/components/ADempiere/Form/Issues/component/Comment.vue
@@ -2895,4 +2895,11 @@ export default defineComponent({
     width: 100%;
   }
 }
+.el-timeline-item__wrapper{
+  font-size: 10px !important
+}
+.previwer-disable {
+  margin-top: -12px;
+  margin-bottom: -18px;
+}
 </style>

--- a/src/components/ADempiere/FormDefinition/IssueManagement/IssueFeed/issueLog.vue
+++ b/src/components/ADempiere/FormDefinition/IssueManagement/IssueFeed/issueLog.vue
@@ -18,7 +18,9 @@
 
 <template>
   <el-card class="list-comments">
-    <issue-avatar :user="comment.user" style="font-size: 10px" />
+    <div style="border-bottom:1px solid #e6ebf5">
+      <issue-avatar :user="comment.user" style="font-size: 10px;" />
+    </div>
     <el-descriptions :column="1" style="margin-top: 10px; margin-bottom:10px">
       <el-descriptions-item
         v-for="log in comment.change_logs"


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
font size in comment
#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif
before
![image](https://github.com/solop-develop/frontend-core/assets/78000356/fe14f226-7816-446a-b5ef-fd2661d50922)

after
![image](https://github.com/solop-develop/frontend-core/assets/78000356/4f6b3d7b-9e96-414e-9bb2-99aad63b5c67)


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
fixed: https://github.com/solop-develop/frontend-core/issues/2009