### PR TITLE
fix: Smart Browse query with `IN` and `NOT IN`.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/browser/getters.js
+++ b/src/store/modules/ADempiere/dictionary/browser/getters.js
@@ -193,15 +193,15 @@ export default {
         }
       }
 
-      if (!isEmptyValue(value) || isNullOperator) {
-        queryParams.push({
-          columnName: column_name,
-          operator,
-          value,
-          valueTo,
-          values
-        })
-      }
+      // if ((!isEmptyValue(value) || !isEmptyValue(valueTo) || !isEmptyValue(values)) || isNullOperator) {
+      queryParams.push({
+        columnName: column_name,
+        operator,
+        value,
+        valueTo,
+        values
+      })
+      // }
     })
 
     return queryParams


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature


#### Screenshot or Gif

https://github.com/solop-develop/frontend-core/assets/20288327/b3e48433-cb3b-4162-8c83-be54d925a98c




#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1164
