### PR TITLE
fix: Align view only web buttons

### DIFF
--- a/src/components/ADempiere/FormDefinition/WTrialBalance/index.vue
+++ b/src/components/ADempiere/FormDefinition/WTrialBalance/index.vue
@@ -164,7 +164,7 @@
           </el-col>
           <el-col :span="8">
             <el-form-item
-              style="margin-left: 20%;text-align:center"
+              style="text-align:center"
             >
               <template slot="label">
                 {{ $t('form.WTrialBalance.showPeriod') }}
@@ -172,7 +172,7 @@
               <el-switch v-model="showPeriod" @change="visibleColumn" />
             </el-form-item>
             <el-form-item
-              style="margin-left: 27%; text-align:center"
+              style="text-align:center; margin-left: 5%;"
             >
               <template slot="label">
                 {{ $t('form.WTrialBalance.showAccumulated') }}
@@ -180,14 +180,8 @@
               <el-switch v-model="showAccumulated" @change="visibleColumn" />
             </el-form-item>
             <el-form-item
-              class="front-item-w-trial-balance"
-              style="text-align: center; margin-top: -5%;"
+              style="text-align: center; margin-top:7%; margin-right:10%; float:right"
             >
-              <template slot="label">
-                <b style="color: transparent;">
-                  {{ $t('form.WTrialBalance.cubeReport') }}
-                </b>
-              </template>
               <el-button
                 plain
                 type="success"


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
align buttons and switch
#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif
before
![image](https://github.com/solop-develop/frontend-core/assets/78000356/12fc1dff-4411-4249-9722-344c5499ee0a)


after
![image](https://github.com/solop-develop/frontend-core/assets/78000356/4e51bde1-f117-4118-ab12-a139f2cfef75)

#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
fixed: https://github.com/solop-develop/frontend-core/issues/1554