### PR TITLE
fix: Hide fields web only button

### DIFF
--- a/src/components/ADempiere/FormDefinition/WTrialBalance/index.vue
+++ b/src/components/ADempiere/FormDefinition/WTrialBalance/index.vue
@@ -18,7 +18,24 @@
 
 <template>
   <div>
+    <el-button
+      v-if="isVisible"
+      type="text"
+      style="float: right; z-index: 5; margin-top:10px"
+      :circle="true"
+      icon="el-icon-arrow-up"
+      @click="changeView(false)"
+    />
+    <el-button
+      v-if="!isVisible"
+      type="text"
+      style="float:right; z-index: 5; margin-top:10px"
+      :circle="true"
+      icon="el-icon-arrow-down"
+      @click="changeView(true)"
+    />
     <el-card
+      v-show="isVisible"
       shadow="header"
       :body-style="{ padding: '10px 20px', margin: '0px' }"
     >
@@ -274,7 +291,7 @@ export default defineComponent({
     /**
      * Ref
      */
-
+    const isVisible = ref(true)
     const showPeriod = ref(false)
     const showAccumulated = ref(false)
     // Values
@@ -576,9 +593,13 @@ export default defineComponent({
 
       return sums
     }
+    function changeView(data) {
+      isVisible.value = data
+    }
     visibleColumn()
     return {
       //  Values
+      isVisible,
       showPeriod,
       showAccumulated,
       porcent,
@@ -618,7 +639,8 @@ export default defineComponent({
       visiblePeriod,
       visibleAccumulated,
       visibleColumn,
-      visibleAll
+      visibleAll,
+      changeView
     }
   }
 })


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
collapse to hide fields web-only fields
#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif

https://github.com/solop-develop/frontend-core/assets/78000356/7d5c5aec-95f7-4b1b-9d3e-90946bef0ed7


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
fixed: https://github.com/solop-develop/frontend-core/issues/1554