### PR TITLE
feat: Change `container_id` to `parent_id` on dependent fields

### DIFF
--- a/src/api/ADempiere/dictionary/index.ts
+++ b/src/api/ADempiere/dictionary/index.ts
@@ -20,39 +20,6 @@
 import { request } from '@/utils/ADempiere/request'
 
 /**
- * Request dictionary Window metadata
- * @param {number} id, identifier
- */
-export function requestWindowMetadata({
-  id
-}) {
-  return request({
-    url: `/dictionary/windows/${id}`,
-    method: 'get'
-  })
-    .then(windowResponse => {
-      const { convertWindow } = require('@/utils/ADempiere/apiConverts/dictionary.js')
-      return convertWindow(windowResponse)
-    })
-}
-
-/**
- * Request Get Tabs
- * @param {number} id
- */
-export function requestTabsMetadata({
-  id
-}) {
-  return request({
-    url: `/dictionary/tabs/${id}`,
-    method: 'get'
-  })
-    .then(responde => {
-      return responde
-    })
-}
-
-/**
  * GET References
  * @param {String} id
  */
@@ -93,30 +60,6 @@ export function requestProcessMetadata({
 }) {
   return request({
     url: `/dictionary/processes/${id}`,
-    method: 'get',
-    params: {
-      language,
-      client_id: clientId,
-      role_id: roleId,
-      user_id: userId
-    }
-  })
-}
-
-/**
- * Request dictionary Smart Browser metadata
- * @param {string} uuid universally unique identifier
- * @param {number} id, identifier
- */
-export function requestBrowserMetadata({
-  id,
-  language,
-  clientId,
-  roleId,
-  userId
-}) {
-  return request({
-    url: `/dictionary/browsers/${id}`,
     method: 'get',
     params: {
       language,

--- a/src/api/ADempiere/dictionary/smart-browser.js
+++ b/src/api/ADempiere/dictionary/smart-browser.js
@@ -1,18 +1,20 @@
-// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
-// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
-// Contributor(s): Yamel Senih ysenih@erpya.com www.erpya.com
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2018-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
 
 // Get Instance for connection
 import { request } from '@/utils/ADempiere/request'
@@ -23,20 +25,20 @@ import { request } from '@/utils/ADempiere/request'
  * @param {number} id, identifier
  */
 export function requestBrowserMetadata({
-  uuid,
-  id
+  id,
+  language,
+  clientId,
+  roleId,
+  userId
 }) {
   return request({
-    url: '/dictionary/browser',
+    url: `/dictionary/browsers/${id}`,
     method: 'get',
     params: {
-      uuid,
-      id
+      language,
+      client_id: clientId,
+      role_id: roleId,
+      user_id: userId
     }
   })
-    .then(browserResponse => {
-      const { convertBrowser } = require('@/utils/ADempiere/apiConverts/dictionary.js')
-
-      return convertBrowser(browserResponse)
-    })
 }

--- a/src/api/ADempiere/dictionary/window.js
+++ b/src/api/ADempiere/dictionary/window.js
@@ -19,30 +19,6 @@
 // Get Instance for connection
 import { request } from '@/utils/ADempiere/request'
 
-/**
- * Request dictionary Window metadata
- * @param {string} uuid universally unique identifier
- * @param {number} id, identifier
- */
-export function requestWindowMetadata({
-  uuid,
-  id
-}) {
-  return request({
-    url: '/dictionary/window',
-    method: 'get',
-    params: {
-      uuid,
-      id
-    }
-  })
-    .then(windowResponse => {
-      const { convertWindow } = require('@/utils/ADempiere/apiConverts/dictionary.js')
-
-      return convertWindow(windowResponse)
-    })
-}
-
 export function requestReference({
   uuid,
   columnName

--- a/src/api/ADempiere/dictionary/window.ts
+++ b/src/api/ADempiere/dictionary/window.ts
@@ -42,3 +42,17 @@ export function requestWindowMetadata({
     }
   })
 }
+
+/**
+ * Request Get Tabs
+ * @param {number} id
+ */
+export function requestTabMetadata({
+  id,
+  windowId
+}) {
+  return request({
+    url: `/dictionary/windows/${windowId}/tabs/${id}`,
+    method: 'get'
+  })
+}

--- a/src/store/modules/ADempiere/dictionary/browser/actions.js
+++ b/src/store/modules/ADempiere/dictionary/browser/actions.js
@@ -21,7 +21,7 @@ import router from '@/router'
 import store from '@/store'
 
 // API Request Methods
-import { requestBrowserMetadata } from '@/api/ADempiere/dictionary/index.ts'
+import { requestBrowserMetadata } from '@/api/ADempiere/dictionary/smart-browser.js'
 
 // Constants
 import {

--- a/src/store/modules/ADempiere/panel/actions.js
+++ b/src/store/modules/ADempiere/panel/actions.js
@@ -478,8 +478,8 @@ const actions = {
         // new implementation
         fieldId = fieldDependentDefinition.id
         columnName = fieldDependentDefinition.column_name
-        containerUuid = fieldDependentDefinition.container_uuid
-        containerName = fieldDependentDefinition.container_name
+        containerUuid = fieldDependentDefinition.parent_uuid
+        containerName = fieldDependentDefinition.parent_name
       }
 
       // Get all fields on different container


### PR DESCRIPTION
Change `container_id` to `parent_id`, `container_uuid` to `parent_uuid`, change `container_name` to `parent_name`.

As `OpenSearch Gateway RS`.

![imagen](https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/a1e1280c-777b-48bc-891c-a872fa1f1679)
