### PR TITLE
fix: Smart Browse without close when process

### DIFF
--- a/src/store/modules/ADempiere/dictionary/browser/actions.js
+++ b/src/store/modules/ADempiere/dictionary/browser/actions.js
@@ -158,7 +158,6 @@ export default {
           }
 
           resolve(browserDefinition)
-
           const { process } = browserDefinition
           if (!isEmptyValue(process)) {
             dispatch('setModalDialog', {
@@ -177,20 +176,21 @@ export default {
                   })
                   return
                 }
-
                 store.dispatch('startProcessOfBrowser', {
                   parentUuid: browserDefinition.uuid,
                   containerUuid: process.uuid
                 }).then(processOutputResponse => {
                   // close current page
-                  const currentRoute = router.app._route
-                  const tabViewsVisited = rootGetters.visitedViews
-                  dispatch('tagsView/delView', currentRoute)
-                  // go to back page
-                  const oldRouter = tabViewsVisited[tabViewsVisited.length - 1]
-                  router.push({
-                    path: oldRouter.path
-                  }, () => {})
+                  if (isEmptyValue(parentUuid)) {
+                    const currentRoute = router.app._route
+                    const tabViewsVisited = rootGetters.visitedViews
+                    dispatch('tagsView/delView', currentRoute)
+                    // go to back page
+                    const oldRouter = tabViewsVisited[tabViewsVisited.length - 1]
+                    router.push({
+                      path: oldRouter.path
+                    }, () => {})
+                  }
                 })
               },
               beforeOpen: ({ parentUuid: browserUuid, containerUuid }) => {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
SB does not close after performing an action from a window
#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif


https://github.com/solop-develop/frontend-core/assets/78000356/2f63e652-5061-4aea-9670-83afa358d5da


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
fixed: https://github.com/solop-develop/frontend-core/issues/2195