### PR TITLE
fix: Close only sb from registry

### DIFF
--- a/src/store/modules/ADempiere/dictionary/browser/actions.js
+++ b/src/store/modules/ADempiere/dictionary/browser/actions.js
@@ -181,7 +181,7 @@ export default {
                   containerUuid: process.uuid
                 }).then(processOutputResponse => {
                   // close current page
-                  if (isEmptyValue(parentUuid)) {
+                  if (!isEmptyValue(parentUuid)) {
                     const currentRoute = router.app._route
                     const tabViewsVisited = rootGetters.visitedViews
                     dispatch('tagsView/delView', currentRoute)

--- a/src/store/modules/ADempiere/processManager.js
+++ b/src/store/modules/ADempiere/processManager.js
@@ -261,6 +261,12 @@ const processManager = {
             dispatch('setBrowserDefaultValues', {
               containerUuid: parentUuid
             })
+            if (isEmptyValue(recordId) || isEmptyValue(windowsUuid)) {
+              commit('setBrowserData', {
+                containerUuid: parentUuid,
+                isLoaded: true
+              })
+            }
           })
           .catch(error => {
             isProcessedError = true


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
 Close only sb from registry
#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif

https://github.com/solop-develop/frontend-core/assets/78000356/bed39331-d37f-4e74-935a-b7eef631e1d6


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
fixed: https://github.com/solop-develop/frontend-core/issues/2195