### PR TITLE
fix: Load `Form` dictionary by cache.

### DIFF
--- a/src/api/ADempiere/dictionary/index.ts
+++ b/src/api/ADempiere/dictionary/index.ts
@@ -75,11 +75,22 @@ export function requestProcessMetadata({
  * @param {number} id, identifier
  */
 export function requestForm({
-  id
+  id,
+  // mandatory to open search
+  language,
+  clientId,
+  roleId,
+  userId
 }) {
   return request({
     url: `/dictionary/forms/${id}`,
-    method: 'get'
+    method: 'get',
+    params: {
+      language,
+      client_id: clientId,
+      role_id: roleId,
+      user_id: userId
+    }
   })
 }
 

--- a/src/store/modules/ADempiere/formDefinition.js
+++ b/src/store/modules/ADempiere/formDefinition.js
@@ -19,7 +19,7 @@
 import Vue from 'vue'
 
 import router from '@/router'
-import language from '@/lang'
+import lang from '@/lang'
 
 // Constants
 import { CONTAINER_FORM_PREFIX } from '@/utils/ADempiere/dictionary/form/index.js'
@@ -30,6 +30,9 @@ import { requestForm } from '@/api/ADempiere/dictionary/index.ts'
 // Utils and Helper Methods
 import { showMessage } from '@/utils/ADempiere/notification'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
+import {
+  getCurrentClient, getCurrentRole
+} from '@/utils/ADempiere/auth'
 
 const form = {
   state: {
@@ -63,13 +66,23 @@ const form = {
         commit('addForm', metadataForm)
       }
     },
-    getFormFromServer({ commit, dispatch }, {
+
+    getFormFromServer({ commit, dispatch, rootGetters }, {
       id,
       routeToDelete
     }) {
       return new Promise(resolve => {
+        const language = rootGetters['getCurrentLanguage']
+        const clientId = getCurrentClient()
+        const roleId = getCurrentRole()
+        const userId = rootGetters['user/getUserId']
+
         requestForm({
-          id
+          id,
+          language,
+          clientId,
+          roleId,
+          userId
         })
           .then(formResponse => {
             // Panel for save on store
@@ -89,13 +102,14 @@ const form = {
             }, () => {})
             dispatch('tagsView/delView', routeToDelete)
             showMessage({
-              message: language.t('page.login.unexpectedError'),
+              message: lang.t('page.login.unexpectedError'),
               type: 'error'
             })
             console.warn(`Dictionary form - Error ${error.code}: ${error.message}.`)
           })
       })
     },
+
     changeFormAttribute({ commit, getters }, {
       containerUuid,
       form,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce
When the url query is missing some mandatory parameter in the frontend you get a 502 error (bad gatweay) but that is very ambiguous because it does not tell the user what was the error or why it was caused.

In this case the example is missing the mandatory `rol_id` parameter, also the error is now answered with the status code in addition to the message.

### Before this changes
![imagen](https://github.com/adempiere/dictionary_rs/assets/20288327/a65431d9-940f-44a1-b0d6-8dfe9c678339)

#### After this changes
![imagen](https://github.com/adempiere/dictionary_rs/assets/20288327/c528ea68-d6ab-4b25-9698-db3f5720b845)

#### Additional context

fixes https://github.com/solop-develop/frontend-core/issues/2278

#### Additional context
Add any other context about the problem here.
