### PR TITLE
fix: `Account` reference table name.

### DIFF
--- a/src/utils/ADempiere/references.js
+++ b/src/utils/ADempiere/references.js
@@ -370,6 +370,9 @@ export function getTableNameFromReference(columnName, displayTypeId) {
   }
   if ([ID.id, SEARCH.id, TABLE.id, TABLE_DIRECT.id].includes(displayTypeId)) {
     tableName = columnName.replaceAll(/(_ID_To|_ID)$/g, '')
+    if (columnName.endsWith('_Acct')) {
+      tableName = 'C_ElementValue'
+    }
   } else if (LIST.id === displayTypeId) {
     tableName = 'AD_Reference'
   } else if (LOCATION_ADDRESS.id === displayTypeId) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

- Add `C_ElementValue` as table name when column `_Acct` is `Table` or `Search`.

#### Screenshot or Gif


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
