### PR TITLE
fix: `Organization` and `Warehouse` fields show by default if tab is document.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -17,7 +17,9 @@
  */
 
 // Constants
-import { ACTIVE, PROCESSED, PROCESSING } from '@/utils/ADempiere/constants/systemColumns'
+import {
+  ACTIVE, PROCESSED, PROCESSING, ORGANIZATION, WAREHOUSE
+} from '@/utils/ADempiere/constants/systemColumns'
 import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils.js'
 import { ID, YES_NO } from '@/utils/ADempiere/references'
 
@@ -216,7 +218,7 @@ export default {
       fieldsList = storedTab.fieldsList
     }
 
-    const { isParentTab, link_column_name, parent_column_name } = storedTab
+    const { isParentTab, link_column_name, parent_column_name, is_document } = storedTab
 
     const attributesDisplayColumn = []
     const attributesObject = {}
@@ -256,6 +258,10 @@ export default {
             parentUuid,
             columnName
           })
+        }
+
+        if (is_document && [ORGANIZATION, WAREHOUSE].includes(columnName)) {
+          // parsedDefaultValue = -1
         }
 
         attributesObject[columnName] = parsedDefaultValue

--- a/src/utils/ADempiere/dictionary/window/index.js
+++ b/src/utils/ADempiere/dictionary/window/index.js
@@ -29,6 +29,7 @@ import {
   ACTIVE, CLIENT, DOCUMENT_ACTION,
   DOCUMENT_NO, DOCUMENT_STATUS, CURRENCY,
   PROCESSING, PROCESSED, UUID, VALUE, // READ_ONLY_FORM_COLUMNS
+  ORGANIZATION, WAREHOUSE,
   RECORD_ID,
   LOG_COLUMNS_NAME_LIST
 } from '@/utils/ADempiere/constants/systemColumns'
@@ -202,8 +203,11 @@ export function evaluateDefaultFieldShowed({
     return true
   }
 
-  const { isParentTab, link_column_name, parent_column_name } = store.getters.getStoredTab(parentUuid, containerUuid)
+  const { isParentTab, link_column_name, parent_column_name, is_document } = store.getters.getStoredTab(parentUuid, containerUuid)
   if (!isParentTab && (link_column_name === column_name || parent_column_name === column_name)) {
+    return true
+  }
+  if (is_document && [ORGANIZATION, WAREHOUSE].includes(column_name)) {
     return true
   }
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

When tab is document, showed by default `Organization` and `Warehouse` field.

#### Screenshot or Gif


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
