### PR TITLE
fix: Number value on identifier column.

### DIFF
--- a/src/utils/ADempiere/contextUtils/evaluator.js
+++ b/src/utils/ADempiere/contextUtils/evaluator.js
@@ -192,7 +192,11 @@ export class evaluator {
       firstEval = firstEval.replace(/['"]/g, '').trim() // strip ' and "
     }
     // Handling of ID compare (null => 0)
-    if (first.endsWith('_ID') && isEmptyValue(firstEval)) {
+    if (isEmptyValue(firstEval) &&
+      (firstEval.endsWith('_ID') || firstEval.endsWith('_ID_To') ||
+      firstEval === 'AD_Key' || firstEval === 'AD_Display' ||
+      firstEval.endsWith('atedBy') || firstEval.endsWith('_Acct'))
+    ) {
       // TODO: Evaluate with -1
       firstEval = '0'
     }
@@ -220,7 +224,10 @@ export class evaluator {
       secondEval = secondEval.replace(/['"]/g, '').trim() // strip ' and " for string values
     }
     if (isEmptyValue(secondEval) &&
-      (second.endsWith('_ID') || second.endsWith('ID_To') || second.endsWith('atedBy') || second.endsWith('_Acct'))) {
+      (second.endsWith('_ID') || second.endsWith('_ID_To') ||
+      second === 'AD_Key' || second === 'AD_Display' ||
+      second.endsWith('atedBy') || second.endsWith('_Acct'))
+    ) {
       // TODO: Evaluate with -1
       secondEval = '0'
     }

--- a/src/utils/ADempiere/references.js
+++ b/src/utils/ADempiere/references.js
@@ -372,6 +372,10 @@ export function getTableNameFromReference(columnName, displayTypeId) {
     tableName = columnName.replaceAll(/(_ID_To|_ID)$/g, '')
     if (columnName.endsWith('_Acct')) {
       tableName = 'C_ElementValue'
+    } else if (columnName.endsWith('atedBy')) {
+      tableName = 'AD_User'
+    } else if (columnName === 'AD_Display' || columnName === 'AD_Key') {
+      tableName = 'AD_Column'
     }
   } else if (LIST.id === displayTypeId) {
     tableName = 'AD_Reference'

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -430,16 +430,19 @@ export function parsedValueComponent({
       if (typeof value === 'boolean') {
         value = convertBooleanToString(value)
       }
-      // Table (18) or Table Direct (19)
-      if (
-        (TABLE_DIRECT.id === displayType || TABLE.id === displayType ||
-        SEARCH.id || IMAGE.id || ACCOUNT_ELEMENT.id ||
-        LOCATOR_WAREHOUSE.id || PRODUCT_ATTRIBUTE.id || RESOURCE_ASSIGNMENT.id) &&
-        (columnName.endsWith('_ID') || columnName.endsWith('_ID_To') ||
-        columnName === 'AD_Key' || columnName === 'AD_Display' ||
-        columnName.endsWith('atedBy') || columnName.endsWith('_Acct'))
-      ) {
-        if (!isEmptyValue(value)) {
+      if (!isEmptyValue(value)) {
+        // Table (18) or Table Direct (19)
+        if (
+          TABLE_DIRECT.id === displayType || IMAGE.id || ACCOUNT_ELEMENT.id ||
+          LOCATOR_WAREHOUSE.id || PRODUCT_ATTRIBUTE.id || RESOURCE_ASSIGNMENT.id
+        ) {
+          value = Number(value)
+        } else if (
+          (TABLE.id === displayType || SEARCH.id) &&
+          (columnName.endsWith('_ID') || columnName.endsWith('_ID_To') ||
+          columnName === 'AD_Key' || columnName === 'AD_Display' ||
+          columnName.endsWith('atedBy') || columnName.endsWith('_Acct'))
+        ) {
           value = Number(value)
         }
       }

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -22,7 +22,11 @@ import store from '@/store'
 
 // Constants
 import { SPECIAL_ZERO_ID_TABLES } from '@/utils/ADempiere//constants/systemColumns'
-import { LIST, TABLE, TABLE_DIRECT } from '@/utils/ADempiere/references.js'
+import {
+  ACCOUNT_ELEMENT, IMAGE,
+  LOCATOR_WAREHOUSE, PRODUCT_ATTRIBUTE, RESOURCE_ASSIGNMENT,
+  LIST, SEARCH, TABLE, TABLE_DIRECT
+} from '@/utils/ADempiere/references.js'
 import { DISPLAY_COLUMN_PREFIX, IDENTIFIER_COLUMN_SUFFIX } from '@/utils/ADempiere/dictionaryUtils'
 import { OPERATION_PATTERN } from '@/utils/ADempiere/formatValue/numberFormat.js'
 
@@ -415,6 +419,7 @@ export function parsedValueComponent({
       break
 
     case 'FieldAccount':
+    case 'FieldImage':
     case 'FieldLocationAddress':
     case 'FieldProductAttribute':
     case 'FieldSearch':
@@ -426,8 +431,14 @@ export function parsedValueComponent({
         value = convertBooleanToString(value)
       }
       // Table (18) or Table Direct (19)
-      if (TABLE_DIRECT.id === displayType || TABLE.id === displayType &&
-        (columnName.endsWith('_ID_To') || columnName.endsWith(IDENTIFIER_COLUMN_SUFFIX))) {
+      if (
+        (TABLE_DIRECT.id === displayType || TABLE.id === displayType ||
+        SEARCH.id || IMAGE.id || ACCOUNT_ELEMENT.id ||
+        LOCATOR_WAREHOUSE.id || PRODUCT_ATTRIBUTE.id || RESOURCE_ASSIGNMENT.id) &&
+        (columnName.endsWith('_ID') || columnName.endsWith('_ID_To') ||
+        columnName === 'AD_Key' || columnName === 'AD_Display' ||
+        columnName.endsWith('atedBy') || columnName.endsWith('_Acct'))
+      ) {
         if (!isEmptyValue(value)) {
           value = Number(value)
         }


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

When display type is:
- TABLE_DIRECT.
- IMAGE.
- ACCOUNT_ELEMENT.
- LOCATOR_WAREHOUSE.
- PRODUCT_ATTRIBUTE.
- RESOURCE_ASSIGNMENT

Or And column name ends with `_ID`, `_ID_To`, `atedBy` or `_Acct`, and display type:
- TABLE.
- SEARCH.

The value is type numeric, 



#### Screenshot or Gif


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
