### PR TITLE
Fix: Parse date in grid mode

### DIFF
--- a/src/store/modules/ADempiere/system.js
+++ b/src/store/modules/ADempiere/system.js
@@ -41,7 +41,6 @@ const system = {
     },
     setLanguagesList: (state, payload) => {
       const languagesList = payload
-
       state.languagesList = Object.freeze(languagesList)
     }
   },
@@ -60,8 +59,8 @@ const system = {
                 ...language,
                 languageISO: language.language_iso,
                 languageName: language.language_name,
-                datePattern: convertDateFormat(language.datePattern),
-                timePattern: convertDateFormat(language.timePattern)
+                datePattern: convertDateFormat(language.date_pattern),
+                timePattern: convertDateFormat(language.time_pattern)
               }
             })
 

--- a/src/utils/ADempiere/valueFormat.js
+++ b/src/utils/ADempiere/valueFormat.js
@@ -97,7 +97,11 @@ export function formatField({
       formattedValue = formatDateTemp({
         value,
         isTime: false,
-        format: optionalFormat
+        format: getDateFormat({
+          format: 'YYYY-MM-DD',
+          isTime: false,
+          isDate: true
+        })
       })
       break
 

--- a/src/utils/ADempiere/valueFormat.js
+++ b/src/utils/ADempiere/valueFormat.js
@@ -98,7 +98,7 @@ export function formatField({
         value,
         isTime: false,
         format: getDateFormat({
-          format: 'YYYY-MM-DD',
+          format: optionalFormat,
           isTime: false,
           isDate: true
         })


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif

![Image](https://github.com/solop-develop/frontend-core/assets/45974454/f6d9808d-d8c1-404d-89a2-b984e67270ea)


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
