### PR TITLE
fix: Sort table when is lookup and insensitive case.

### DIFF
--- a/src/components/ADempiere/DataTable/Browser/index.vue
+++ b/src/components/ADempiere/DataTable/Browser/index.vue
@@ -73,6 +73,7 @@
         :column-key="fieldAttributes.columnName"
         :prop="fieldAttributes.columnName"
         sortable
+        :sort-by="fieldAttributes.sortByProperty"
         :min-width="widthColumn(fieldAttributes)"
         :fixed="fieldAttributes.isFixedTableColumn"
       >

--- a/src/store/modules/ADempiere/browserManager.js
+++ b/src/store/modules/ADempiere/browserManager.js
@@ -31,7 +31,9 @@ import {
 import {
   ROW_ATTRIBUTES, ROW_KEY_ATTRIBUTES, ROWS_OF_RECORDS_BY_PAGE
 } from '@/utils/ADempiere/tableUtils'
-import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
+import {
+  DISPLAY_COLUMN_PREFIX, SORT_COLUMN_PREFIX
+} from '@/utils/ADempiere/dictionaryUtils'
 
 // Utils and Helper Methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
@@ -277,6 +279,20 @@ const browserControl = {
           .then(browserSearchResponse => {
             const recordsList = browserSearchResponse.records.map((record, rowIndex) => {
               const { values } = record
+
+              // TODO: Test peformance.
+              Object.keys(values).forEach(key => {
+                const currentValue = values[key]
+                if (key.startsWith(DISPLAY_COLUMN_PREFIX)) {
+                  // Add column with sort values to correct sorting
+                  let sortValue = ''
+                  if (!isEmptyValue(currentValue)) {
+                    sortValue = currentValue.toLowerCase()
+                  }
+                  values[SORT_COLUMN_PREFIX + key] = sortValue
+                }
+              })
+
               return {
                 ...values,
                 // datatables app attributes

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -44,6 +44,11 @@ import {
 export const DISPLAY_COLUMN_PREFIX = `DisplayColumn_`
 
 /**
+ * Sort Column Prefix on Column Name: "SortColumn_ColumnName"
+ */
+export const SORT_COLUMN_PREFIX = `SortColumn_`
+
+/**
  * Identifier Column Suffix on Column Name: "_ID"
  */
 export const IDENTIFIER_COLUMN_SUFFIX = `_ID`
@@ -243,7 +248,7 @@ export function generateField({
     isSupported: componentReference.isSupported,
     size: componentReference.size || DEFAULT_SIZE,
     displayColumnName: DISPLAY_COLUMN_PREFIX + columnName, // key to display column
-    sortByProperty: !isSupportLookup(fieldToGenerate.display_type) ? columnName : DISPLAY_COLUMN_PREFIX + columnName,
+    sortByProperty: !isSupportLookup(fieldToGenerate.display_type) ? columnName : SORT_COLUMN_PREFIX + DISPLAY_COLUMN_PREFIX + columnName,
     // value attributes
     parsedDefaultValue,
     parsedDefaultValueTo,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif
Before this changes:

https://github.com/solop-develop/frontend-core/assets/20288327/1bc3df3a-50cb-4efb-94af-6aaccb62019f



After this changes:

https://github.com/solop-develop/frontend-core/assets/20288327/ea6196da-346a-4c51-96cd-b26e22043f43



#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/2357
