### PR TITLE
fix: Smart Browse dispatch default search when default value is empty response

### DIFF
--- a/src/components/ADempiere/FieldDefinition/mixin/mixinField.js
+++ b/src/components/ADempiere/FieldDefinition/mixin/mixinField.js
@@ -247,6 +247,10 @@ export default {
           contextColumnNames: this.metadata.contextColumnNames,
           defaultValue: this.metadata.default_value,
           //
+          inTable: this.metadata.inTable,
+          rowIndex: this.metadata.rowIndex,
+          rowUid: this.metadata.rowUid,
+          //
           uuid: this.metadata.uuid,
           id: this.metadata.id,
           columnName: this.metadata.column_name,

--- a/src/store/modules/ADempiere/defaultValueManager.js
+++ b/src/store/modules/ADempiere/defaultValueManager.js
@@ -230,7 +230,8 @@ const defaultValueManager = {
               displayedValue: displayValue,
               value: valueOfServer,
               uuid: values.UUID,
-              isActive: is_active
+              isActive: is_active,
+              reason: 'Successful default value'
             })
           })
           .catch(error => {
@@ -252,6 +253,11 @@ const defaultValueManager = {
               containerUuid,
               columnName: columnName + UNIVERSALLY_UNIQUE_IDENTIFIER_COLUMN_SUFFIX,
               value: undefined
+            })
+
+            resolve({
+              ...defaultEmptyResponse,
+              reason: 'Error request default value'
             })
             console.warn(`Error getting default value (${columnName}) from server. Error code ${error.code}: ${error.message}.`)
           })


### PR DESCRIPTION
… response.

<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif

Before this changes

https://github.com/solop-develop/frontend-core/assets/20288327/458c6dc4-ca89-4a2b-8616-543540bd1b75

After this changes

https://github.com/solop-develop/frontend-core/assets/20288327/7fc6fa00-63b5-4219-9bff-1effc763c254




#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/2372
