### PR TITLE
fix: Hidde trab translation without flag and table name end `_Trl`.

### DIFF
--- a/src/utils/ADempiere/dictionary/window/index.js
+++ b/src/utils/ADempiere/dictionary/window/index.js
@@ -1427,9 +1427,10 @@ export function generateTabs({
       })
       return false
     }
-    return !(
-      itemTab.is_translation_tab
-    )
+    if (itemTab.is_translation_tab || (itemTab.table.table_name.endsWith('_Trl'))) {
+      return false
+    }
+    return true
   }).map((currentTab, index, listTabs) => {
     const isParentTab = Boolean(firstTabTableName === currentTab.table_name)
     const parentTabs = listTabs


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Screenshot or Gif

Before this changes
![imagen](https://github.com/solop-develop/frontend-core/assets/20288327/153188e1-3d3d-4874-b1a6-773f43e116bf)

After this changes
![imagen](https://github.com/solop-develop/frontend-core/assets/20288327/3e4a9b43-5f6b-4441-9cd2-5daea5f21b4c)


