### PR TITLE
Fix: Context attributes in `Order` serach field

### DIFF
--- a/src/store/modules/ADempiere/field/search/orderFieldSearch.js
+++ b/src/store/modules/ADempiere/field/search/orderFieldSearch.js
@@ -242,7 +242,8 @@ const fieldOrder = {
           parentUuid,
           containerUuid: originContainerUuid,
           contextColumnNames,
-          isBooleanToString: true
+          isBooleanToString: true,
+          format: 'object'
         })
         let contextAttributes = '{}'
         if (!isEmptyValue(contextAttributesList)) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif
**Before**

https://github.com/user-attachments/assets/4a5c8a75-f3a4-4a7a-9337-2be58651ff42

**After**


https://github.com/user-attachments/assets/1f43e689-d050-4300-adb7-800c321feb6c


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
fixed: https://github.com/solop-develop/frontend-core/issues/277