### PR TITLE
fix: Hide Quotes In Operators

### DIFF
--- a/src/lang/ADempiere/es/operators.ts
+++ b/src/lang/ADempiere/es/operators.ts
@@ -36,20 +36,20 @@ const operators = {
   onlyOperators: {
     compareSearch: 'Comparar la Búsqueda',
     operator: 'Operador de comparación',
-    equal: '"="',
-    not_equal: '"<>"',
-    like: '"~"',
-    not_like: '"!~"',
-    greater: '">"',
-    greater_equal: '">="',
-    less: '"<"',
-    less_equal: '"<="',
-    between: '">-<"',
-    not_between: '"<->"',
+    equal: '=',
+    not_equal: '<>',
+    like: '~',
+    not_like: '!~',
+    greater: '>',
+    greater_equal: '>=',
+    less: '<',
+    less_equal: '<=',
+    between: '>-<',
+    not_between: '<->',
     null: 'No tiene valor',
     not_null: 'Tiene un valor',
-    in: '"()"',
-    not_in: '"!()"'
+    in: '()',
+    not_in: '!()'
   }
 }
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif
Before

![imagen](https://github.com/user-attachments/assets/e86ee7c0-1d2f-4470-905e-30d76e4b5bf1)
![imagen](https://github.com/user-attachments/assets/ebede1b3-30bb-4f36-aacb-17594ab1840c)


After

![imagen](https://github.com/user-attachments/assets/716a7542-40dc-41e4-b61a-b0a4be4d43da)

![imagen](https://github.com/user-attachments/assets/aae0beef-8cc2-4893-911d-51a1c614c5ce)


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
