### PR TITLE
Fix: Width column report

### DIFF
--- a/src/components/ADempiere/Report/Data/DataReport.vue
+++ b/src/components/ADempiere/Report/Data/DataReport.vue
@@ -363,10 +363,10 @@ export default defineComponent({
         const widths = {}
         columns.value.forEach((column, index) => {
           let width = 0
-          if (column.column_width > 0) {
+          if (column.column_width > 0 && column.is_fixed_width) {
             width = column.column_width
           }
-          if (column.column_width <= 0 && column.column_characters_size > 0) {
+          if (column.column_characters_size > 0 && !column.is_fixed_width) {
             let fontCode = 15
             let character = column.column_characters_size
             if (!isEmptyValue(column.title) && column.column_characters_size < column.title.length) {
@@ -389,6 +389,9 @@ export default defineComponent({
             } else {
               width = 300
             }
+          }
+          if (!column.is_fixed_width && column.column_width > 0 && column.column_width > width) {
+            width = column.column_width
           }
           widths[index] = width
         })

--- a/src/components/ADempiere/Report/Data/DataReport.vue
+++ b/src/components/ADempiere/Report/Data/DataReport.vue
@@ -368,9 +368,9 @@ export default defineComponent({
           }
           if (column.column_width <= 0 && column.column_characters_size > 0) {
             let fontCode = 15
-            let character = 15
-            if (column.column_characters_size > 5) {
-              character = column.column_characters_size
+            let character = column.column_characters_size
+            if (!isEmptyValue(column.title) && column.column_characters_size < column.title.length) {
+              character = column.title.length
             }
             if (!isEmptyValue(column.font_code)) {
               const number = column.font_code.replace(/[^\d]/g, '')

--- a/src/components/ADempiere/Report/Data/DataReport.vue
+++ b/src/components/ADempiere/Report/Data/DataReport.vue
@@ -369,7 +369,7 @@ export default defineComponent({
           if (column.column_width <= 0 && column.column_characters_size > 0) {
             let fontCode = 15
             let character = 15
-            if (column.column_characters_size > 10) {
+            if (column.column_characters_size > 5) {
               character = column.column_characters_size
             }
             if (!isEmptyValue(column.font_code)) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif

https://github.com/user-attachments/assets/089cc0f0-4d2c-4f00-87bb-994845b09684

Validating 

1- if the column comes with column_width > 0 && is_fixed_width = true then take that value as column width
2- if the column column.is_fixed_width = false && column_characters_size > 0 
  - a variable with font size 15 is created in case the font is not defined. 
  - validate if column_characters_size > title in case it is true column_characters_size is used if not use title.length
  - font size * number of characters is calculated

3- in case none of the above happens, the validations are used to know if it is numeric, date, bool, decimal, etc.

4- at the end of all we validate
  -if the fixed column flag comes false && column_width > 0 && column_width > to the sum of the previous operations
  -if that is true then the column will have the width that the back-end sends in column_width
  -if not then the column will have the width of the sum of the above operations

#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
