### PR TITLE
Fix: Width Column Report Enginer

### DIFF
--- a/src/components/ADempiere/Report/Data/DataReport.vue
+++ b/src/components/ADempiere/Report/Data/DataReport.vue
@@ -387,7 +387,7 @@ export default defineComponent({
             width = column.column_width
           }
           if (column.column_characters_size > 0 && !column.is_fixed_width) {
-            let fontCode = 15
+            let fontCode = 10
             let character = column.column_characters_size
             if (!isEmptyValue(column.title) && column.column_characters_size < column.title.length) {
               character = column.title.length
@@ -396,6 +396,7 @@ export default defineComponent({
               const number = column.font_code.replace(/[^\d]/g, '')
               fontCode = number
             }
+            fontCode = fontCode * 0.9
             width = character * fontCode
           }
           if (width === 0) {
@@ -413,7 +414,7 @@ export default defineComponent({
           if (!column.is_fixed_width && column.column_width > 0 && column.column_width > width) {
             width = column.column_width
           }
-          widths[index] = width
+          widths[index] = width + 10
         })
         return widths
       }
@@ -529,5 +530,9 @@ export default defineComponent({
   display: flex;
   justify-content: flex-end;
   margin-right:20px;
+}
+.el-table th.el-table__cell > .cell{
+  padding-left: 5px !important;
+  padding-right: 5px !important;
 }
 </style>


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Screenshot or Gif
![imagen](https://github.com/user-attachments/assets/cd559148-f481-412f-9cb0-688c29b69794)

- The font size is being multiplied * 0.9 
- Reduced padding of column sides from 10 to 5px 
- 10 are being added to the end of each sum to calculate the column width


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
fixes: https://github.com/solop-develop/frontend-core/issues/2671
fixes: https://github.com/solop-develop/frontend-core/issues/2698