### PR TITLE
feat: Overwrite display type on reference to `Button` fields.

### DIFF
--- a/src/components/ADempiere/FieldDefinition/FieldOptions/ContextInfo/index.vue
+++ b/src/components/ADempiere/FieldDefinition/FieldOptions/ContextInfo/index.vue
@@ -134,7 +134,6 @@ import { defineComponent, computed, onMounted } from '@vue/composition-api'
 import store from '@/store'
 
 // Constants
-import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 import { BUTTON, ID, IMAGE } from '@/utils/ADempiere/references'
 
 // Utils and Helper Methods
@@ -162,15 +161,18 @@ export default defineComponent({
         columnName: column_name
       })
     })
+
     const displayValueField = computed(() => {
-      if (!(isLookup(props.fieldAttributes.display_type) || [ID.id, IMAGE.id, BUTTON.id].includes(props.fieldAttributes.display_type))) {
+      const {
+        parentUuid, containerUuid, displayColumnName, display_type
+      } = props.fieldAttributes
+      if (!(isLookup(display_type) || [ID.id, IMAGE.id, BUTTON.id].includes(display_type))) {
         return null
       }
-      const { parentUuid, containerUuid, column_name } = props.fieldAttributes
       return store.getters.getValueOfFieldOnContainer({
         parentUuid,
         containerUuid,
-        columnName: DISPLAY_COLUMN_PREFIX + column_name
+        columnName: displayColumnName
       })
     })
 

--- a/src/components/ADempiere/FieldDefinition/FieldOptions/DocumentStatus/index.vue
+++ b/src/components/ADempiere/FieldDefinition/FieldOptions/DocumentStatus/index.vue
@@ -118,6 +118,11 @@ import DocumentStatusTag from '@/components/ADempiere/ContainerOptions/DocumentS
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 import { convertStringToBoolean } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 
+/**
+ * Based on:
+ * - https://github.com/adempiere/adempiere/blob/develop/client/src/org/compiere/apps/APanel.java
+ * - https://github.com/adempiere/adempiere/blob/develop/zkwebui/WEB-INF/src/org/adempiere/webui/panel/AbstractADWindowPanel.java
+ */
 export default defineComponent({
   name: 'DocumentStatus',
 

--- a/src/components/ADempiere/Form/AcctViewer/index.vue
+++ b/src/components/ADempiere/Form/AcctViewer/index.vue
@@ -52,8 +52,9 @@ import TableRecords from './TableRecords'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 
 /**
- * org.compiere.acct.AcctViewer
- * org.adempiere.webui.acct.WAcctViewer
+ * Based on:
+ * - https://github.com/adempiere/adempiere/blob/develop/client/src/org/compiere/acct/AcctViewer.java
+ * - https://github.com/adempiere/adempiere/blob/develop/zkwebui/WEB-INF/src/org/adempiere/webui/acct/WAcctViewer.java
  */
 export default defineComponent({
   name: 'AcctViewer',

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -19,7 +19,7 @@
 import lang from '@/lang'
 
 // Constants
-import REFERENCES, { YES_NO, DEFAULT_SIZE, BUTTON, LIST } from '@/utils/ADempiere/references'
+import REFERENCES, { BUTTON, DEFAULT_SIZE, LIST, YES_NO } from '@/utils/ADempiere/references'
 import {
   FIELD_OPERATORS_LIST, OPERATOR_EQUAL,
   OPERATOR_LIKE, OPERATOR_GREATER_EQUAL, OPERATOR_LESS_EQUAL, OPERATOR_BETWEEN
@@ -114,13 +114,26 @@ export function generateField({
 
   let isColumnDocumentStatus = false
   let componentReference = evalutateTypeField(fieldToGenerate.display_type)
-  // overwrite `Button` to `List` display type on `PaymentRule`.
-  if ([columnName, fieldToGenerate.element_name].includes('PaymentRule') && fieldToGenerate.display_type === BUTTON.id) {
-    componentReference = LIST
-    fieldToGenerate.display_type = LIST.id
-    fieldToGenerate.reference = {
-      table_name: 'AD_Ref_List',
-      context_column_names: []
+
+  // overwrite `Button` to `List` or `Table` display type.
+  if (fieldToGenerate.display_type === BUTTON.id) {
+    if ((moreAttributes.isAdvancedQuery || fieldToGenerate.is_query_criteria) &&
+      fieldToGenerate.reference && fieldToGenerate.reference.reference_value_id > 0) {
+      // overwrite if is with reference
+      componentReference = evalutateTypeField(fieldToGenerate.reference.reference_id)
+      fieldToGenerate.display_type = fieldToGenerate.reference.reference_id
+      fieldToGenerate.reference = {
+        table_name: fieldToGenerate.reference.table_name,
+        context_column_names: []
+      }
+    } else if ([columnName, fieldToGenerate.element_name].includes('PaymentRule')) {
+      componentReference = LIST
+      fieldToGenerate.display_type = LIST.id
+      fieldToGenerate.reference = {
+        table_name: 'AD_Ref_List',
+        reference_id: LIST.id,
+        context_column_names: []
+      }
     }
   }
 


### PR DESCRIPTION
If there is a button that has a reference value, for the case of search or smart query criteria you can overwrite the display type to a drop-down list.

### Before this changes
https://github.com/user-attachments/assets/ee012247-5f77-4d58-9f03-33fd05e34bf0

### After this changes
![imagen](https://github.com/user-attachments/assets/9f9564d4-f46b-4227-9ffe-c4c7798e5c5e)

### Addional context
fixes https://github.com/solop-develop/frontend-core/issues/2795