### PR TITLE
Fix: Smaller Default Font Size

### DIFF
--- a/src/components/ADempiere/Report/Data/DataCells.vue
+++ b/src/components/ADempiere/Report/Data/DataCells.vue
@@ -174,7 +174,7 @@ export default defineComponent({
         fontStyle += `color: ${font.color} !important;`
       }
       if (isEmptyValue(font.font_code)) {
-        fontStyle += 'font-size: 10px !important'
+        fontStyle += 'font-size: 11px !important'
       }
       if (!isEmptyValue(font.font_code)) {
         const lastIndex = font.font_code.lastIndexOf('-')

--- a/src/components/ADempiere/Report/Data/DataReport.vue
+++ b/src/components/ADempiere/Report/Data/DataReport.vue
@@ -653,7 +653,7 @@ export default defineComponent({
   background: #ecf5ff;
 }
 .el-table .children-row .cell .el-dropdown {
-  color: #000 !important
+  color: #000
 }
 .reportInfo .el-popover {
   width: 850px !important;

--- a/src/components/ADempiere/Report/Data/DataReport.vue
+++ b/src/components/ADempiere/Report/Data/DataReport.vue
@@ -382,7 +382,7 @@ export default defineComponent({
       if (!isEmptyValue(children) || row.isTopLevel) {
         return 'success-row'
       }
-      return ''
+      return 'children-row'
     }
 
     function getRowClassName({ row, rowIndex }) {
@@ -651,6 +651,9 @@ export default defineComponent({
 .el-table .success-row {
   font-weight: 700;
   background: #ecf5ff;
+}
+.el-table .children-row .cell .el-dropdown {
+  color: #000 !important
 }
 .reportInfo .el-popover {
   width: 850px !important;


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Screenshot or Gif
![imagen](https://github.com/user-attachments/assets/581d8c08-e1e1-42e9-bd79-1886a21d5fb6)





**Font size at 11px** 
**color to #000**

#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
Add any other context about the problem here.
fixes: https://github.com/solop-develop/frontend-core/issues/2696