### PR TITLE
fix: Undefined `iconClass` on menu search.

### DIFF
--- a/src/components/HeaderSearch/index.vue
+++ b/src/components/HeaderSearch/index.vue
@@ -21,12 +21,26 @@
         :label="element.item.title.join(' > ')"
       >
         <span v-if="isMobile">
-          <svg-icon :icon-class="element.item.meta.icon" />
+          <i
+            v-if="element.item.meta.icon.includes('el-icon')"
+            :class="'icon sub-el-icon ' + element.item.meta.icon"
+          />
+          <svg-icon
+            v-else
+            :icon-class="element.item.meta.icon"
+          />
           {{ element.item.title.join(' > ') }}
         </span>
         <span v-else>
           {{ element.item.title.join(' > ') }}
-          <svg-icon :icon-class="element.item.meta.icon" />
+          <i
+            v-if="element.item.meta.icon.includes('el-icon')"
+            :class="'icon sub-el-icon ' + element.item.meta.icon"
+          />
+          <svg-icon
+            v-else
+            :icon-class="element.item.meta.icon"
+          />
         </span>
       </el-option>
     </el-select>

--- a/src/router/modules/ADempiere/staticRoutes.js
+++ b/src/router/modules/ADempiere/staticRoutes.js
@@ -258,6 +258,7 @@ const staticRoutes = [
         meta: {
           title: language.t('route.reportViewer'),
           type: 'report',
+          icon: 'el-icon-data-analysis',
           reportType: ''
         }
       }
@@ -276,6 +277,7 @@ const staticRoutes = [
         meta: {
           title: language.t('route.reportViewer'),
           type: 'report',
+          icon: 'el-icon-data-analysis',
           reportType: ''
         }
       }

--- a/src/views/dashboard/admin/index.vue
+++ b/src/views/dashboard/admin/index.vue
@@ -55,7 +55,7 @@
       <el-col :span="classPanel ? 24 : 16">
         <template v-for="(dashboardAttributes, index) in panelRight">
           <el-col
-            v-if="(isEmptyValue(mainDashboard.chartType) || mainDashboard.name !== dashboardAttributes.name)"
+            v-if="mainDashboard && (isEmptyValue(mainDashboard.chartType) || mainDashboard.name !== dashboardAttributes.name)"
             :key="index"
             :span="24"
             style="padding-right:8px;margin-bottom:2px;"


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature


- Search `Viewer`.
- See web browser console.
The `Report Viewer` is no set icon.

#### Screenshot or Gif

![imagen](https://github.com/user-attachments/assets/cd759117-c381-4ee0-9f62-789177b43d05)


#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/2823
